### PR TITLE
Fix missing laminas-migration bin and autoload path

### DIFF
--- a/bin/laminas-migration
+++ b/bin/laminas-migration
@@ -11,10 +11,12 @@ namespace Laminas\Migration;
 
 use Symfony\Component\Console\Application;
 
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require __DIR__ . '/../vendor/autoload.php';
-} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
-    require __DIR__ . '/../../../autoload.php';
+if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
+    require $a;
+} elseif (file_exists($a = __DIR__ . '/../vendor/autoload.php')) {
+    require $a;
+} elseif (file_exists($a = __DIR__ . '/../autoload.php')) {
+    require $a;
 } else {
     fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
     exit(1);

--- a/bin/laminas-migration
+++ b/bin/laminas-migration
@@ -11,7 +11,14 @@ namespace Laminas\Migration;
 
 use Symfony\Component\Console\Application;
 
-require __DIR__ . '/../../../autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require __DIR__ . '/../../../autoload.php';
+} else {
+    fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
+    exit(1);
+}
 
 $application = new Application('laminas-migration');
 $application->addCommands([

--- a/bin/laminas-migration
+++ b/bin/laminas-migration
@@ -11,7 +11,7 @@ namespace Laminas\Migration;
 
 use Symfony\Component\Console\Application;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../../autoload.php';
 
 $application = new Application('laminas-migration');
 $application->addCommands([

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
             "LaminasTest\\Migration\\": "test/"
         }
     },
+    "bin": [
+        "bin/laminas-migration"
+    ],
     "scripts": {
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

Following the installation steps described [here](https://gist.github.com/weierophinney/df937d870b0d8bded4d1185ef510aaed), the `laminas-migration` is not present in the global `vendor/bin` directory, due to a missing `bin` configuration in `composer.json`.

Secondly, invoking the `laminas-migration` command will fail due to an incorrect path to `autoload.php`.

This PR fixes both issues.

If desired, it is possible to change requiring the autoload file depending on whether the package was installed either as global or dev dependency.