### PR TITLE
Exclude additional phrases from rewriting

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -56,6 +56,9 @@ class Helper
             'doctrine-zend' => 'doctrine-zend',
             'ZendService' => 'ZendService',
             'ZF\Console' => 'ZF\Console',
+            'Zendesk' => 'Zendesk',
+            'Zend_' => 'Zend_', // ZF1 namespaces
+            'zendframework/zendframework' => 'zendframework/zendframework',
 
             // Packages rewrite rules:
             'zenddiagnostics' => 'laminas-diagnostics',


### PR DESCRIPTION
`Zendesk`
`Zend_` - ZF1 namespaces
`zendframework/zendframework` - meta repository which is not rewritten
