### PR TITLE
Remove vendor directory as part of migration

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -56,6 +56,8 @@ class MigrateCommand extends Command
             return 1;
         }
 
+        $path = realpath($path);
+
         $this->removeComposerLock($path);
         $this->removeVendorDirectory($path);
 
@@ -64,7 +66,7 @@ class MigrateCommand extends Command
         }
 
         foreach ($this->findProjectFiles($path, $input->getOption('exclude')) as $file) {
-            $this->performReplacements($file, $path);
+            $this->performReplacements($file->getRealPath(), $path);
         }
 
         return 0;
@@ -169,7 +171,7 @@ class MigrateCommand extends Command
     /**
      * @param string $path
      * @param string[] $excludePaths
-     * @return RecursiveIteratorIterator
+     * @return RecursiveIteratorIterator|SplFileInfo[]
      */
     private function findProjectFiles($path, array $excludePaths)
     {


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | yes
| RFC         | no

### Description

This patch adds logic to remove the configured vendor directory, if it exists, prior to performing the migration. This ensures:

- it will not rewrite code in the vendor directory
- a clean install will occur after the migration

What I observed was that if ZF components had been installed as dependencies of other third-party libraries previously, Composer would detect those, and decide no installation task was required for those dependencies — which in turn meant the dependency plugin had nothing to intercept and rewrite.

As part of this fix, I also rewrote some of the internal logic, performing some "extract method" refactors so I could better understand the logic.