### PR TITLE
fix: return early when no deps are installed

### DIFF
--- a/src/Command/NestedDepsCommand.php
+++ b/src/Command/NestedDepsCommand.php
@@ -81,6 +81,10 @@ EOH;
         }
 
         $data = json_decode(trim(implode("\n", $results)));
+        if (! isset($data->installed)) {
+            return 1;
+        }
+
         $packages = [];
 
         foreach ($data->installed as $package) {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature or refactor or existing code: develop branch
-->

|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

When dependencies are not installed we should reaturn early.
Message from composer will be shown, as follows:

```
Checking for Zend Framework packages in project
No dependencies installed. Try running composer install or update.
```

Before PHP error occurs:

```
Warning: Invalid argument supplied for foreach() in
laminas-migration/src/Command/NestedDepsCommand.php on line 86
```

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
