### PR TITLE
Inject space after bridge module

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -308,7 +308,7 @@ class MigrateCommand extends Command
 
         $search = $matches['prelude'] . $matches['space'];
         $replacement = sprintf(
-            '%s%s\'Laminas\ZendFrameworkBridge\'%s',
+            '%s%s\'Laminas\ZendFrameworkBridge\',%s',
             $matches['prelude'],
             $matches['space'],
             $matches['space']


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

The migration script was not injecting a comma character after the `Laminas\ZendFrameworkBridge` entry when injecting the component as a module in migrated packages.