### PR TITLE
Provide more extensive file filtering features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^5.6 || ^7.0",
         "ext-json": "*",
         "laminas/laminas-zendframework-bridge": "^0.3.7",
-        "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0"
+        "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ebaa4cf5d2216a2badee0ee69d324fde",
+    "content-hash": "6d02885bfa10c9f4ae469a63bc3c02d8",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -358,6 +358,7 @@ EOH;
 
             $path = $file->getPathname();
             foreach ($regexFilters as $regex) {
+                // Pattern is not quoted, to allow quantities, character sets, and grouping
                 $pattern = sprintf('#%s#', $regex);
                 if (preg_match($pattern, $path)) {
                     // If any filter matches, we process the file.
@@ -390,6 +391,8 @@ EOH;
 
         // Create list of filenames to check against
         $fileMatches = array_map(static function ($exclusion) {
+            // Pattern is quoted, as it should be a literal. We want to match
+            // files as the end segment of a path.
             return sprintf('#%s$#', preg_quote($exclusion, '#'));
         }, $exclusions);
 

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -390,7 +390,7 @@ EOH;
 
         // Create list of filenames to check against
         $fileMatches = array_map(static function ($exclusion) {
-            return sprintf('#%s$#', preg_quote($exclusion, '|'));
+            return sprintf('#%s$#', preg_quote($exclusion, '#'));
         }, $exclusions);
 
         /**

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -305,7 +305,7 @@ EOH;
                     return true;
                 }
 
-                if ($current->isFile() && ! $filter($current->getPathname())) {
+                if ($current->isFile() && $filter($current->getPathname())) {
                     return true;
                 }
 
@@ -329,11 +329,11 @@ EOH;
 
         return static function ($path) use ($filters) {
             foreach ($filters as $filter) {
-                if ($filter($path)) {
-                    return true;
+                if (! $filter($path)) {
+                    return false;
                 }
             }
-            return false;
+            return true;
         };
     }
 
@@ -359,11 +359,11 @@ EOH;
                 $pattern = sprintf('#%s#', $filter);
                 if (preg_match($pattern, $path)) {
                     // If any filter matches, we process the file
-                    return false;
+                    return true;
                 }
             }
             // No filter matched
-            return true;
+            return false;
         };
 
         return $filters;
@@ -401,10 +401,10 @@ EOH;
         $filters[] = static function ($path) use ($excludePaths) {
             foreach ($excludePaths as $excludePath) {
                 if (strpos($path, $excludePath) !== false) {
-                    return true;
+                    return false;
                 }
             }
-            return false;
+            return true;
         };
 
         return $filters;
@@ -431,10 +431,10 @@ EOH;
             foreach ($excludePaths as $excludePath) {
                 $pattern = sprintf('|%s$|', preg_quote($excludePath, '|'));
                 if (preg_match($pattern, $path)) {
-                    return true;
+                    return false;
                 }
             }
-            return false;
+            return true;
         };
 
         return $filters;

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -26,8 +26,8 @@ class MigrateCommand extends Command
 Migrate a project or library to target Laminas, Expressive, and/or Apigility
 packages.
 
-Basic Usage
------------
+<info>Basic Usage</info>
+<info>-----------</info>
 
 In most cases, the command can be run without any arguments, in which case it
 will migrate the project in the current directory, rewriting any files that
@@ -37,8 +37,8 @@ equivalents.
 If you wish to specify a path other than the current working directory, use the
 --path option.
 
-Excluding Files
----------------
+<info>Excluding Files</info>
+<info>---------------</info>
 
 If you wish to exclude all files under a given directory from migration, use
 the --exclude (or -e) option. A common use case for that is "--exclude data"
@@ -62,8 +62,8 @@ The above would only rewrite files with the suffixes ".php", ".php.dist",
 ".phtml", and ".json", as well as Dockerfiles and scripts matching the name
 "php-entrypoint".
 
-Injections
-----------
+<info>Injections</info>
+<info>----------</info>
 
 The tooling provides three potential new injections into your code base:
 

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -340,7 +340,7 @@ EOH;
             /**
              * @return bool Always returns true.
              */
-            return function () {
+            return static function () {
                 return true;
             };
         }
@@ -382,12 +382,12 @@ EOH;
         array_unshift($exclusions, $this->locateVendorDirectory($projectPath));
 
         // Create list of directory patterns to check against
-        $directoryMatches = array_map(function ($exclusion) {
+        $directoryMatches = array_map(static function ($exclusion) {
             return sprintf('/%s', trim($exclusion, '/\\'));
         }, $exclusions);
 
         // Create list of filenames to check against
-        $fileMatches = array_map(function ($exclusion) {
+        $fileMatches = array_map(static function ($exclusion) {
             return sprintf('#%s$#', preg_quote($exclusion, '|'));
         }, $exclusions);
 

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -20,6 +20,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+use const DIRECTORY_SEPARATOR;
+
 class MigrateCommand extends Command
 {
     const HELP = <<< EOH
@@ -231,8 +233,8 @@ EOH;
     {
         $composer  = json_decode(file_get_contents($path . '/composer.json'), true);
         return isset($composer['config']['vendor-dir'])
-            ? sprintf('%s/%s/', $path, $composer['config']['vendor-dir'])
-            : sprintf('%s/vendor/', $path);
+            ? sprintf('%s%s%s', $path, DIRECTORY_SEPARATOR, $composer['config']['vendor-dir'])
+            : sprintf('%s%svendor', $path, DIRECTORY_SEPARATOR);
     }
 
     /**
@@ -376,14 +378,14 @@ EOH;
     private function createExcludeFilter(array $exclusions, $projectPath)
     {
         // Prepend most common exclusions
-        array_unshift($exclusions, sprintf('%s/.hg', $projectPath));
-        array_unshift($exclusions, sprintf('%s/.svn', $projectPath));
-        array_unshift($exclusions, sprintf('%s/.git', $projectPath));
+        array_unshift($exclusions, sprintf('%s%s.hg', $projectPath, DIRECTORY_SEPARATOR));
+        array_unshift($exclusions, sprintf('%s%s.svn', $projectPath, DIRECTORY_SEPARATOR));
+        array_unshift($exclusions, sprintf('%s%s.git', $projectPath, DIRECTORY_SEPARATOR));
         array_unshift($exclusions, $this->locateVendorDirectory($projectPath));
 
         // Create list of directory patterns to check against
         $directoryMatches = array_map(static function ($exclusion) {
-            return sprintf('/%s', trim($exclusion, '/\\'));
+            return sprintf('%s%s', DIRECTORY_SEPARATOR, trim($exclusion, '/\\'));
         }, $exclusions);
 
         // Create list of filenames to check against

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -22,10 +22,71 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class MigrateCommand extends Command
 {
+    const HELP = <<< EOH
+Migrate a project or library to target Laminas, Expressive, and/or Apigility
+packages.
+
+Basic Usage
+-----------
+
+In most cases, the command can be run without any arguments, in which case it
+will migrate the project in the current directory, rewriting any files that
+contain references to Zend Framework artifacts to instead reference the Laminas
+equivalents.
+
+If you wish to specify a path other than the current working directory, use the
+--path option.
+
+Excluding Files
+---------------
+
+If you wish to exclude all files under a given directory from migration, use
+the --exclude (or -e) option. A common use case for that is "--exclude data"
+or "--exclude data/cache". The --exclude option can be issued multiple times,
+one for each directory you wish to exclude.
+
+To exclude individual files, use the --exclude-file (-x) option. This option
+can also be issued multiple times.
+
+To provide a regular expression filter for matching files to rewrite, use the
+--filter (-f) option. Files that match the regular expression will be
+rewritten. This option can also be issued multiple times; if a file matches
+any filter, it will be rewritten.
+
+Injections
+----------
+
+The tooling provides three potential new injections into your code base:
+
+- Injecting the laminas/laminas-dependency-plugin Composer plugin as a
+  dependency. This plugin intercepts requests to install Zend Framework
+  packages, and substitutes the Laminas equivalents.
+
+- Injecting the `Laminas\ZendFrameworkBridge` module into MVC and Apigility
+  applications. This module provides configuration post processing to replace,
+  at runtime, references to known Zend Framework configuration keys and
+  dependencies with the Laminas equivalents.
+
+- Injecting the `Laminas\ZendFrameworkBridge\ConfigPostProcessor` class as a
+  `Laminas\ConfigAggregator\ConfigAggregator` post processor into Expressive
+  applications. This class provides configuration post processing to replace,
+  at runtime, references to known Zend Framework configuration keys and
+  dependencies with the Laminas equivalents.
+
+If you wish to prevent injection of the laminas/laminas-dependency-plugin in
+your application, use the --no-plugin option.
+
+If you wish to prevent injection of either the laminas-zendframework-bridge
+Module or ConfigPostProcessor into your application, use the
+--no-config-processor option.
+
+EOH;
+
     protected function configure()
     {
         $this->setName('migrate')
             ->setDescription('Migrate a project or third-party library to target Laminas/Expressive/Apigility')
+            ->setHelp(self::HELP)
             ->addArgument(
                 'path',
                 InputArgument::OPTIONAL,
@@ -37,6 +98,25 @@ class MigrateCommand extends Command
                 'e',
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Directories in which to exclude rewrites. Always excludes .git and the configured vendor directories.'
+            )
+            ->addOption(
+                'exclude-file',
+                'x',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Individual files in which to exclude rewrites.'
+            )
+            ->addOption(
+                'filter',
+                'f',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Filters'
+            )
+            ->addOption(
+                'no-config-processor',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not install either the laminas/laminas-zendframework-bridge'
+                . ' Module or ConfigPostProcessor in your application'
             )
             ->addOption(
                 'no-plugin',

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -146,8 +146,10 @@ EOH;
         $this->removeVendorDirectory($path, $io);
         $this->injectDependencyPlugin($path, $input->getOption('no-plugin'), $io);
         $this->migrateProjectFiles($path, $input->getOption('exclude'), $io);
-        $this->injectBridgeModule($path, $io);
-        $this->injectBridgeConfigPostProcessor($path, $io);
+
+        $disableConfigProcessorInjection = $input->getOption('no-config-processor');
+        $this->injectBridgeModule($path, $disableConfigProcessorInjection, $io);
+        $this->injectBridgeConfigPostProcessor($path, $disableConfigProcessorInjection, $io);
 
         $io->success('Migration complete!');
         $io->text([
@@ -362,12 +364,18 @@ EOH;
     }
 
     /**
-     * param string $path
+     * @param string $path
+     * @param bool $disableConfigProcessorInjection
      */
-    private function injectBridgeModule($path, SymfonyStyle $io)
+    private function injectBridgeModule($path, $disableConfigProcessorInjection, SymfonyStyle $io)
     {
         $modulesConfig = sprintf('%s/config/modules.config.php', $path);
         if (! file_exists($modulesConfig)) {
+            return;
+        }
+
+        if ($disableConfigProcessorInjection) {
+            $io->writeln('<info>Skipping injection of bridge module by request (--no-config-processor)</info>');
             return;
         }
 
@@ -400,11 +408,20 @@ EOH;
 
     /**
      * @param string $path
+     * @param bool $disableConfigProcessorInjection
      */
-    private function injectBridgeConfigPostProcessor($path, SymfonyStyle $io)
+    private function injectBridgeConfigPostProcessor($path, $disableConfigProcessorInjection, SymfonyStyle $io)
     {
         $configFile = sprintf('%s/config/config.php', $path);
         if (! file_exists($configFile)) {
+            return;
+        }
+
+        if ($disableConfigProcessorInjection) {
+            $io->writeln(
+                '<info>Skipping injection of bridge configuration post processor'
+                . ' by request (--no-config-processor)</info>'
+            );
             return;
         }
 


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| Bugfix      | no
| BC Break    | no
| New Feature | yes
| RFC         | no

### Description

This patch provides a number of improvements as suggested by several users.

First, it adds full documentation of the command when invoked using `laminas-migration help migrate`, complete with examples.

Second, it updates the `--exclude` option to also allow providing filenames to exclude.

Third, it adds new options:

- `--no-config-processor` will skip injection of either the laminas-zendframework-bridge module or config post processor if the tool detects that an injection would otherwise be made.

- `--filter|-f` can be invoked multiple times, and allows providing a regular expression (minus any delimiters). If a file does not match any filters provided, it will not be processed. (If it matches at least one filter, and no exclude rules match, it will be processed.)