### PR TITLE
Ensure path comparisons work cross-platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "bin/laminas-migration"
     ],
     "scripts": {
+        "check-compat": "for VERSION in 5.6 7.0 7.1 7.2 7.3 7.4;do ./vendor/bin/phpcs -- -p src --standard=PHPCompatibility --runtime-set testVersion $VERSION ; done",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit"

--- a/composer.lock
+++ b/composer.lock
@@ -8,23 +8,24 @@
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "0.3.7",
+            "version": "0.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6524baeca2a44a7e1423254775f5c41873d9c358"
+                "reference": "706cb6b2b548fe7ce2cc1dce51b6c92f8f562043"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6524baeca2a44a7e1423254775f5c41873d9c358",
-                "reference": "6524baeca2a44a7e1423254775f5c41873d9c358",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/706cb6b2b548fe7ce2cc1dce51b6c92f8f562043",
+                "reference": "706cb6b2b548fe7ce2cc1dce51b6c92f8f562043",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1"
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1",
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
             "extra": {
@@ -54,7 +55,7 @@
                 "laminas",
                 "zf"
             ],
-            "time": "2019-11-12T18:22:37+00:00"
+            "time": "2019-11-14T15:47:19+00:00"
         },
         {
             "name": "psr/container",
@@ -425,16 +426,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.3",
+            "version": "9.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "1af08ca3861048a8bfb39d0405d0ac3e50ba2696"
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1af08ca3861048a8bfb39d0405d0ac3e50ba2696",
-                "reference": "1af08ca3861048a8bfb39d0405d0ac3e50ba2696",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
                 "shasum": ""
             },
             "require": {
@@ -479,7 +480,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-11-11T03:25:23+00:00"
+            "time": "2019-11-15T04:12:02+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -487,12 +488,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "e3e6456e753326a096303e96b0f759fe789e63e8"
+                "reference": "40fb2c205dd261ab6bb42ec29545934f0db7026f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e3e6456e753326a096303e96b0f759fe789e63e8",
-                "reference": "e3e6456e753326a096303e96b0f759fe789e63e8",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/40fb2c205dd261ab6bb42ec29545934f0db7026f",
+                "reference": "40fb2c205dd261ab6bb42ec29545934f0db7026f",
                 "shasum": ""
             },
             "conflict": {
@@ -560,7 +561,7 @@
                 "league/commonmark": "<0.18.3",
                 "magento/magento1ce": "<1.9.4.3",
                 "magento/magento1ee": ">=1,<1.14.4.3",
-                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.3",
+                "magento/product-community-edition": ">=2,<2.2.10|>=2.3,<2.3.2",
                 "monolog/monolog": ">=1.8,<1.12",
                 "namshi/jose": "<2.2",
                 "onelogin/php-saml": "<2.10.4",
@@ -629,7 +630,7 @@
                 "symfony/security-guard": ">=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.2.12|>=4.3,<4.3.8",
                 "symfony/serializer": ">=2,<2.0.11",
-                "symfony/symfony": ">=2,<2.7.51|>=2.8,<2.8.50|>=3,<3.4.26|>=4,<4.1.12|>=4.2,<4.2.7",
+                "symfony/symfony": ">=2,<2.8.52|>=3,<3.4.35|>=4,<4.2.12|>=4.3,<4.3.8",
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
                 "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
@@ -697,7 +698,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-11-13T10:25:51+00:00"
+            "time": "2019-11-19T14:18:57+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/src/BridgeConfigPostProcessor.php
+++ b/src/BridgeConfigPostProcessor.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function preg_match;
+use function sprintf;
+use function str_replace;
+
+class BridgeConfigPostProcessor
+{
+    /**
+     * @param string $path
+     * @param bool $disableConfigProcessorInjection
+     * @return void
+     */
+    public function inject($path, $disableConfigProcessorInjection, SymfonyStyle $io)
+    {
+        $configFile = sprintf('%s/config/config.php', $path);
+        if (! file_exists($configFile)) {
+            return;
+        }
+
+        if ($disableConfigProcessorInjection) {
+            $io->writeln(
+                '<info>Skipping injection of bridge configuration post processor'
+                . ' by request (--no-config-processor)</info>'
+            );
+            return;
+        }
+
+        $io->writeln(sprintf(
+            '<info>Injecting Laminas\ZendFrameworkBridge\ConfigPostProcessor into %s</info>',
+            $configFile
+        ));
+
+        $contents = file_get_contents($configFile);
+        if (! preg_match('/(?<prelude>\$cacheConfig\[\'config_cache_path\'\])\);/s', $contents, $matches)) {
+            $io->error('- File is not in expected format; aborting injection');
+            $io->text(
+                'You will need to manually add the "Laminas\ZendFrameworkBridge\ConfigPostProcessor"'
+                . ' in your ConfigAggregator initialization.'
+            );
+            return;
+        }
+
+        $search = $matches['prelude'];
+        $replacement = sprintf(
+            '%s, [\Laminas\ZendFrameworkBridge\ConfigPostProcessor::class]',
+            $matches['prelude']
+        );
+        $newContents = str_replace($search, $replacement, $contents);
+
+        file_put_contents($configFile, $newContents);
+    }
+}

--- a/src/BridgeModule.php
+++ b/src/BridgeModule.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function preg_match;
+use function sprintf;
+use function str_replace;
+
+class BridgeModule
+{
+    /**
+     * @param string $path
+     * @param bool $disableConfigProcessorInjection
+     * @return void
+     */
+    public function inject($path, $disableConfigProcessorInjection, SymfonyStyle $io)
+    {
+        $modulesConfig = sprintf('%s/config/modules.config.php', $path);
+        if (! file_exists($modulesConfig)) {
+            return;
+        }
+
+        if ($disableConfigProcessorInjection) {
+            $io->writeln('<info>Skipping injection of bridge module by request (--no-config-processor)</info>');
+            return;
+        }
+
+        $io->writeln(sprintf(
+            '<info>Injecting Laminas\ZendFrameworkBridge module into %s</info>',
+            $modulesConfig
+        ));
+
+        $contents = file_get_contents($modulesConfig);
+        if (! preg_match('/(?<prelude>return\s+(array\(|\[))(?<space>\s+)/s', $contents, $matches)) {
+            $io->error('- File is not in expected format; aborting injection');
+            $io->text(
+                'You will need to manually add an entry for "Laminas\ZendFrameworkBridge"'
+                . ' in your module configuration.'
+            );
+            return;
+        }
+
+        $search = $matches['prelude'] . $matches['space'];
+        $replacement = sprintf(
+            '%s%s\'Laminas\ZendFrameworkBridge\',%s',
+            $matches['prelude'],
+            $matches['space'],
+            $matches['space']
+        );
+        $newContents = str_replace($search, $replacement, $contents);
+
+        file_put_contents($modulesConfig, $newContents);
+    }
+}

--- a/src/ComposerLockFile.php
+++ b/src/ComposerLockFile.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function file_exists;
+use function unlink;
+
+class ComposerLockFile
+{
+    /**
+     * @param string $path
+     */
+    public function remove($path, SymfonyStyle $io)
+    {
+        if (! file_exists($path . '/composer.lock')) {
+            return;
+        }
+        $io->writeln('<info>Removing composer.lock</info>');
+        unlink($path . '/composer.lock');
+    }
+}

--- a/src/DependencyPlugin.php
+++ b/src/DependencyPlugin.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function file_get_contents;
+use function json_decode;
+
+class DependencyPlugin
+{
+    /**
+     * @param string $path
+     * @param null|bool $noPluginOption
+     * @return void
+     */
+    public function inject($path, $noPluginOption, SymfonyStyle $io)
+    {
+        if ($noPluginOption) {
+            return;
+        }
+
+        $io->writeln('<info>Injecting laminas-dependency-plugin into composer.json</info>');
+        $json = json_decode(file_get_contents($path . '/composer.json'), true);
+        $json['require']['laminas/laminas-dependency-plugin'] = '^0.1.2';
+        Helper::writeJson($path . '/composer.json', $json);
+    }
+}

--- a/src/Directory.php
+++ b/src/Directory.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use function dirname;
+use function is_dir;
+use function is_link;
+use function mkdir;
+use function preg_replace;
+use function rmdir;
+use function scandir;
+use function sprintf;
+use function str_replace;
+use function substr;
+use function ucfirst;
+use function unlink;
+
+class Directory
+{
+    /**
+     * If the path provided references a directory that does not yet exist,
+     * create it.
+     *
+     * @param string $path
+     * @return void
+     */
+    public function createParentDirectory($path)
+    {
+        $directory = dirname($path);
+        if (is_dir($directory)) {
+            return;
+        }
+        mkdir($directory, 0775, $recursive = true);
+    }
+
+    /**
+     * Normalize a Windows-based path to Unix-friendly format.
+     *
+     * @param string $path
+     * @return string
+     */
+    public function normalizePath($path)
+    {
+        $path = str_replace('\\', '/', $path);
+        $path = preg_replace('|(?<=.)/+|', '/', $path);
+        if (':' === substr($path, 1, 1)) {
+            $path = ucfirst($path);
+        }
+        return $path;
+    }
+
+    /**
+     * @param string $path
+     * @return void
+     */
+    public function rmdir($path)
+    {
+        foreach (scandir($path) as $file) {
+            if ($file === '.' || $file === '..') {
+                continue;
+            }
+            $test = sprintf('%s/%s', $path, $file);
+            is_dir($test) && ! is_link($test)
+                ? $this->rmdir($test)
+                : unlink($test);
+        }
+        rmdir($path);
+    }
+}

--- a/src/FileFilter.php
+++ b/src/FileFilter.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use RecursiveIterator;
+use SplFileInfo;
+use SplTempFileObject;
+
+use function array_map;
+use function array_unshift;
+use function preg_match;
+use function preg_quote;
+use function sprintf;
+use function strpos;
+use function trim;
+
+class FileFilter
+{
+    /**
+     * @var string[]
+     */
+    private $directoryExclusions = [];
+
+    /** @var string[] */
+    private $exclusions = [];
+
+    /**
+     * @var string[]
+     */
+    private $fileExclusions = [];
+
+    /** @var string */
+    private $path = [];
+
+    /** @var string[] */
+    private $regexes = [];
+
+    /**
+     * @param string $path
+     * @param string[] $regexes
+     * @param string[] $exclusions
+     * @return self
+     */
+    public function __construct($path, array $regexes, array $exclusions)
+    {
+        $this->path       = $path;
+        $this->regexes    = $regexes;
+        $this->exclusions = $exclusions;
+
+        $this->prependCommonExclusions();
+        $this->prepareExclusionPatterns();
+    }
+
+    /**
+     * @return bool True if the file should be processed; false otherwise
+     */
+    public function __invoke(SplFileInfo $file)
+    {
+        if (! $this->applyRegexFilter($file)) {
+            return false;
+        }
+
+        if (! $this->applyExclusionFilter($file)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return bool True if we should process the file, false otherwise.
+     */
+    public function applyRegexFilter(SplFileInfo $file)
+    {
+        if (empty($this->regexes)) {
+            return true;
+        }
+
+        if (! $file->isFile()) {
+            return true;
+        }
+
+        $path = $file->getPathname();
+        foreach ($this->regexes as $regex) {
+            // Pattern is not quoted, to allow quantities, character sets, and grouping
+            $pattern = sprintf('#%s#', $regex);
+            if (preg_match($pattern, $path)) {
+                // If any filter matches, we process the file.
+                return true;
+            }
+        }
+
+        // If no filter matches, we do not process the file.
+        return false;
+    }
+
+    /**
+     * @return bool True if we should process the file, false otherwise.
+     */
+    public function applyExclusionFilter(SplFileInfo $file)
+    {
+        $path = $file->getPathname();
+
+        // Handle directories
+        if ($file->isDir()) {
+            foreach ($this->directoryExclusions as $exclusion) {
+                if (strpos($path, $exclusion) !== false) {
+                    // Matched an exclusion; do not recurse
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Non-directory, non-files cannot be rewritten
+        if (! $file->isFile()) {
+            return false;
+        }
+
+        // Handle files
+        foreach ($this->fileExclusions as $exclusion) {
+            if (preg_match($exclusion, $path)) {
+                // File matches exclusion pattern; do not process
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function prependCommonExclusions()
+    {
+        array_unshift($this->exclusions, '/.hg');
+        array_unshift($this->exclusions, '/.svn');
+        array_unshift($this->exclusions, '/.git');
+    }
+
+    private function prepareExclusionPatterns()
+    {
+        // Create list of directory patterns to check against
+        $directory = new Directory();
+        $this->directoryExclusions = array_map(static function ($exclusion) use ($directory) {
+            return sprintf('/%s', trim($directory->normalizePath($exclusion), '/'));
+        }, $this->exclusions);
+
+        // Create list of filenames to check against
+        $this->fileExclusions = array_map(static function ($exclusion) use ($directory) {
+            $exclusion = $directory->normalizePath($exclusion);
+            // Pattern is quoted, as it should be a literal. We want to match
+            // files as the end segment of a path.
+            return sprintf('#%s$#', preg_quote($exclusion, '#'));
+        }, $this->exclusions);
+    }
+}

--- a/src/MigrateProject.php
+++ b/src/MigrateProject.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function file_get_contents;
+use function file_put_contents;
+use function rename;
+use function sprintf;
+use function strlen;
+use function substr;
+
+class MigrateProject
+{
+    /** @var Directory */
+    private $dir;
+
+    public function __construct()
+    {
+        $this->dir = new Directory();
+    }
+
+    public function __invoke($path, callable $filter, SymfonyStyle $io)
+    {
+        $io->writeln('<info>Performing migration replacements</info>');
+        foreach ($this->traverseFiles($path, $filter) as $file) {
+            $io->writeln(sprintf('- Examining file %s', $file->getRealPath()));
+            $this->performReplacements($file->getRealPath(), $path);
+        }
+    }
+
+    /**
+     * @param string $path
+     * @return RecursiveIteratorIterator|SplFileInfo[]
+     */
+    public function traverseFiles($path, callable $filter)
+    {
+        // Ensure paths are normalized as UNIX style paths, and that we do not
+        // traverse . and ..
+        $dir = new RecursiveDirectoryIterator(
+            $path,
+            RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::UNIX_PATHS
+        );
+
+        return new RecursiveIteratorIterator(new RecursiveCallbackFilterIterator($dir, $filter));
+    }
+
+    /**
+     * Perform replacements in $file, and rename $file if necessary
+     *
+     * @param string $file File being examined and updated
+     * @param string $projectPath Project root path
+     * @return void
+     */
+    public function performReplacements($file, $projectPath)
+    {
+        $content  = file_get_contents($file);
+        $replaced = Helper::replace($content);
+
+        if ($replaced !== $content) {
+            file_put_contents($file, $replaced);
+        }
+
+        // Rename the file if necessary.
+        // Only rewrite the portion under the project root path.
+        $newName = sprintf('%s/%s', $projectPath, Helper::replace(substr($file, strlen($projectPath) + 1)));
+        if ($newName !== $file) {
+            $this->dir->createParentDirectory($newName);
+            rename($file, $newName);
+        }
+    }
+}

--- a/src/MigrateProject.php
+++ b/src/MigrateProject.php
@@ -35,7 +35,6 @@ class MigrateProject
     {
         $io->writeln('<info>Performing migration replacements</info>');
         foreach ($this->traverseFiles($path, $filter) as $file) {
-            $io->writeln(sprintf('- Examining file %s', $file->getRealPath()));
             $this->performReplacements($file->getRealPath(), $path);
         }
     }

--- a/src/VendorDirectory.php
+++ b/src/VendorDirectory.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function file_get_contents;
+use function json_decode;
+use function sprintf;
+
+use const DIRECTORY_SEPARATOR;
+
+class VendorDirectory extends Directory
+{
+    /**
+     * @param string $path Project path
+     * @return string Location of vendor directory
+     */
+    public function locate($path)
+    {
+        $path      = $this->normalizePath($path);
+        $composer  = json_decode(file_get_contents($path . '/composer.json'), true);
+        return isset($composer['config']['vendor-dir'])
+            ? sprintf('%s/%s', $path, $composer['config']['vendor-dir'])
+            : sprintf('%s/vendor', $path);
+    }
+
+    /**
+     * @param string $path
+     */
+    public function remove($path, SymfonyStyle $io)
+    {
+        $vendorDir = $this->locate($path);
+        if (! is_dir($vendorDir)) {
+            return;
+        }
+        $io->writeln('<info>Removing configured vendor directory</info>');
+        $this->rmdir($vendorDir);
+    }
+}

--- a/test/DirectoryTest.php
+++ b/test/DirectoryTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class DirectoryTest extends TestCase
 {
-    public function pathsToNormalize() : iterable
+    public function pathsToNormalize(): iterable
     {
         yield 'unix'    => ['/home/user/project', '/home/user/project'];
         yield 'windows' => ['C:\Users\user\project', 'C:/Users/user/project'];
@@ -22,7 +22,7 @@ class DirectoryTest extends TestCase
     /**
      * @dataProvider pathsToNormalize
      */
-    public function testNormalizePathNormalizesToUnixPaths(string $original, string $expected) : void
+    public function testNormalizePathNormalizesToUnixPaths(string $original, string $expected): void
     {
         $dir = new Directory();
         $this->assertSame($expected, $dir->normalizePath($original));

--- a/test/DirectoryTest.php
+++ b/test/DirectoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Migration;
+
+use Laminas\Migration\Directory;
+use PHPUnit\Framework\TestCase;
+
+class DirectoryTest extends TestCase
+{
+    public function pathsToNormalize() : iterable
+    {
+        yield 'unix'    => ['/home/user/project', '/home/user/project'];
+        yield 'windows' => ['C:\Users\user\project', 'C:/Users/user/project'];
+    }
+
+    /**
+     * @dataProvider pathsToNormalize
+     */
+    public function testNormalizePathNormalizesToUnixPaths(string $original, string $expected) : void
+    {
+        $dir = new Directory();
+        $this->assertSame($expected, $dir->normalizePath($original));
+    }
+}

--- a/test/FileFilterTest.php
+++ b/test/FileFilterTest.php
@@ -18,18 +18,18 @@ use RuntimeException;
 
 class FileFilterTest extends TestCase
 {
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->cleanDirectories();
         $this->prepareDirectories();
     }
 
-    public function tearDown() : void
+    public function tearDown(): void
     {
         $this->cleanDirectories();
     }
 
-    public function cleanDirectories() : void
+    public function cleanDirectories(): void
     {
         $directory = new Directory();
         $baseDir = dirname(__DIR__);
@@ -41,7 +41,7 @@ class FileFilterTest extends TestCase
         }
     }
 
-    public function prepareDirectories() : void
+    public function prepareDirectories(): void
     {
         $baseDir = dirname(__DIR__);
         foreach (['.hg', '.svn'] as $dir) {
@@ -54,7 +54,7 @@ class FileFilterTest extends TestCase
         }
     }
 
-    public function getDirectoryIterator($path) : RecursiveDirectoryIterator
+    public function getDirectoryIterator($path): RecursiveDirectoryIterator
     {
         return new RecursiveDirectoryIterator(
             $path,
@@ -74,7 +74,11 @@ class FileFilterTest extends TestCase
         );
 
         foreach ($files as $file) {
-            $this->assertNotRegExp('!/\.(git|hg|svn)(/|$)!', $file->getRealPath(), 'One or more files matched a VCS directory');
+            $this->assertNotRegExp(
+                '!/\.(git|hg|svn)(/|$)!',
+                $file->getRealPath(),
+                'One or more files matched a VCS directory'
+            );
         }
     }
 
@@ -90,7 +94,11 @@ class FileFilterTest extends TestCase
         );
 
         foreach ($files as $file) {
-            $this->assertNotRegExp('!/vendor(/|$)!', $file->getRealPath(), 'One or more files matched a VCS directory');
+            $this->assertNotRegExp(
+                '!/vendor(/|$)!',
+                $file->getRealPath(),
+                'One or more files matched a VCS directory'
+            );
         }
     }
 
@@ -111,7 +119,11 @@ class FileFilterTest extends TestCase
         }, $exclusions));
 
         foreach ($files as $file) {
-            $this->assertNotRegExp('!/(' . $pattern . ')$!', $file->getRealPath(), 'One or more files matched a VCS directory');
+            $this->assertNotRegExp(
+                '!/(' . $pattern . ')$!',
+                $file->getRealPath(),
+                'One or more files matched a VCS directory'
+            );
         }
     }
 

--- a/test/FileFilterTest.php
+++ b/test/FileFilterTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Migration;
+
+use Laminas\Migration\Directory;
+use Laminas\Migration\FileFilter;
+use PHPUnit\Framework\TestCase;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+
+class FileFilterTest extends TestCase
+{
+    public function setUp() : void
+    {
+        $this->cleanDirectories();
+        $this->prepareDirectories();
+    }
+
+    public function tearDown() : void
+    {
+        $this->cleanDirectories();
+    }
+
+    public function cleanDirectories() : void
+    {
+        $directory = new Directory();
+        $baseDir = dirname(__DIR__);
+        foreach (['.hg', '.svn'] as $dir) {
+            $path = sprintf('%s/%s', $baseDir, $dir);
+            if (is_dir($path)) {
+                $directory->rmdir($path);
+            }
+        }
+    }
+
+    public function prepareDirectories() : void
+    {
+        $baseDir = dirname(__DIR__);
+        foreach (['.hg', '.svn'] as $dir) {
+            $path = sprintf('%s/%s', $baseDir, $dir);
+            if (file_exists($path)) {
+                throw new RuntimeException(sprintf('Directory %s exists, and should not', $path));
+            }
+            mkdir($path);
+            touch($path . '/ignore');
+        }
+    }
+
+    public function getDirectoryIterator($path) : RecursiveDirectoryIterator
+    {
+        return new RecursiveDirectoryIterator(
+            $path,
+            RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::UNIX_PATHS
+        );
+    }
+
+    public function testOmitsVcsDirectoriesByDefault()
+    {
+        $path   = realpath(dirname(__DIR__));
+        $filter = new FileFilter($path, [], []);
+        $files  = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                $this->getDirectoryIterator($path),
+                $filter
+            )
+        );
+
+        foreach ($files as $file) {
+            $this->assertNotRegExp('!/\.(git|hg|svn)(/|$)!', $file->getRealPath(), 'One or more files matched a VCS directory');
+        }
+    }
+
+    public function testDoesNotReturnFilesInExcludedDirectories()
+    {
+        $path   = realpath(dirname(__DIR__));
+        $filter = new FileFilter($path, [], ['/vendor']);
+        $files  = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                $this->getDirectoryIterator($path),
+                $filter
+            )
+        );
+
+        foreach ($files as $file) {
+            $this->assertNotRegExp('!/vendor(/|$)!', $file->getRealPath(), 'One or more files matched a VCS directory');
+        }
+    }
+
+    public function testDoesNotReturnExcludedFiles()
+    {
+        $exclusions = ['CHANGELOG.md', 'COPYRIGHT.md', 'LICENSE.md'];
+        $path       = realpath(dirname(__DIR__));
+        $filter     = new FileFilter($path, [], $exclusions);
+        $files      = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                $this->getDirectoryIterator($path),
+                $filter
+            )
+        );
+
+        $pattern = implode('|', array_map(function ($exclusion) {
+            return preg_quote($exclusion);
+        }, $exclusions));
+
+        foreach ($files as $file) {
+            $this->assertNotRegExp('!/(' . $pattern . ')$!', $file->getRealPath(), 'One or more files matched a VCS directory');
+        }
+    }
+
+    public function testOnlyReturnsFilesMatchingOneOrMoreRegexes()
+    {
+        $regexes = [
+            'src/.*?',
+            'config/.*?',
+            '.*\.md',
+        ];
+
+        $path   = realpath(dirname(__DIR__));
+        $filter = new FileFilter($path, $regexes, []);
+        $files  = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                $this->getDirectoryIterator($path),
+                $filter
+            )
+        );
+
+        foreach ($files as $file) {
+            $matches = false;
+            foreach ($regexes as $regex) {
+                $pattern = sprintf('#%s#', $regex);
+                if (preg_match($pattern, $file->getRealPath())) {
+                    $matches = true;
+                    break;
+                }
+            }
+            $this->assertTrue($matches, sprintf(
+                'File "%s" did not match any regexes, but was still returned',
+                $file->getRealPath()
+            ));
+        }
+    }
+
+    public function testOnlyReturnsFilesMatchingARegexThatAreNotAlsoExcluded()
+    {
+        $regexes = [
+            'src/.*?',
+            'config/.*?',
+            '.*\.md',
+        ];
+
+        $exclusions = [
+            '/vendor',
+            'MigrateCommand.php',
+        ];
+
+        $path   = realpath(dirname(__DIR__));
+        $filter = new FileFilter($path, $regexes, $exclusions);
+        $files  = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                $this->getDirectoryIterator($path),
+                $filter
+            )
+        );
+
+        $exclusionPattern = implode('|', array_map(function ($exclusion) {
+            return preg_quote($exclusion);
+        }, $exclusions));
+
+        foreach ($files as $file) {
+            $this->assertNotRegExp(
+                '!/(' . $exclusionPattern . ')$!',
+                $file->getRealPath(),
+                sprintf('File %s matched a VCS directory', $file->getRealPath())
+            );
+
+            $matches = false;
+            foreach ($regexes as $regex) {
+                $pattern = sprintf('#%s#', $regex);
+                if (preg_match($pattern, $file->getRealPath())) {
+                    $matches = true;
+                    break;
+                }
+            }
+            $this->assertTrue($matches, sprintf(
+                'File "%s" did not match any regexes, but was still returned',
+                $file->getRealPath()
+            ));
+        }
+    }
+}


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

The impetus of this change was from two users reporting issues on Windows when using the migration tool; the vendor and VCS directories were being traversed and rewritten when they should not have been.

To attempt the fix, I needed a way to test the file filtering. As such, I refactored the internals of `MigrateCommand` substantially, extracting several classes:

- `BridgeConfigPostProcessor`
- `BridgeModule`
- `ComposerLockFile`
- `DependencyPlugin`
- `Directory`
- `FileFilter`
- `MigrateProject`
- `VendorDirectory`

The `Directory` class contains logic for common operations such as recursively removing a directory, creating a parent directory, and, most importantly, normalizing a string representing a path or path fragment to conform to Unix filesystem notation.

The logic for filtering files was moved to a dedicated functor class, `FileFilter`, allowing for an easier flow of logic.

Finally, I did an audit of all path comparison operations to ensure they use Unix-style path definitions.

I have provided tests for the `Directory::normalizePath` method and the various logic flows of `FileFilter`, which gives me confidence that the logic is now correct.

I have also had each of the reporters test on their code bases, and they confirmed that the code represented in this patch resolved the issues for them.