### PR TITLE
Ensure we replace references to "Expressive" when imported as a namespace

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -13,7 +13,6 @@ use Laminas\Migration\BridgeModule;
 use Laminas\Migration\ComposerLockFile;
 use Laminas\Migration\DependencyPlugin;
 use Laminas\Migration\FileFilter;
-use Laminas\Migration\Helper;
 use Laminas\Migration\MigrateProject;
 use Laminas\Migration\VendorDirectory;
 use RecursiveCallbackFilterIterator;

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -20,7 +20,9 @@ class Helper
     {
         static $replacements;
 
-        $replacements = $replacements ?: new Replacements();
+        $replacements = $replacements ?: new Replacements([
+            'Expressive\\' => 'Mezzio\\',
+        ]);
         return $replacements->replace($string);
     }
 


### PR DESCRIPTION
We had a report that a user had imported `Zend\Expressive` as a namespace, and then referenced classes later using `Expressive\{subnamespace}\{class}`. Since we were only rewriting `Zend\Expressive`, this caused issues.

The proposed fix is to include references to `Expressive\\` with `Mezzio\\`.