### PR TITLE
Pin laminas-dependency-plugin to ^1.0

### DIFF
--- a/src/DependencyPlugin.php
+++ b/src/DependencyPlugin.php
@@ -28,7 +28,7 @@ class DependencyPlugin
 
         $io->writeln('<info>Injecting laminas-dependency-plugin into composer.json</info>');
         $json = json_decode(file_get_contents($path . '/composer.json'), true);
-        $json['require']['laminas/laminas-dependency-plugin'] = '^0.2';
+        $json['require']['laminas/laminas-dependency-plugin'] = '^1.0';
         Helper::writeJson($path . '/composer.json', $json);
     }
 }


### PR DESCRIPTION
Since it was marked stable, we should be using that version.