### PR TITLE
Add version to command

### DIFF
--- a/bin/laminas-migration
+++ b/bin/laminas-migration
@@ -9,6 +9,7 @@
 
 namespace Laminas\Migration;
 
+use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
 
 if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
@@ -22,7 +23,9 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
     exit(1);
 }
 
-$application = new Application('laminas-migration');
+$version = strstr(Versions::getVersion('laminas/laminas-migration'), '@', true);
+
+$application = new Application('laminas-migration', $version);
 $application->addCommands([
     new Command\MigrateCommand(),
     new Command\NestedDepsCommand(),

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": "^5.6 || ^7.0",
         "ext-json": "*",
         "laminas/laminas-zendframework-bridge": "^1.0",
+        "ocramius/package-versions": "^1.4",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Adds dependency on ocramius/package-versions, and updates `bin/laminas-migration` to detect the version using that tool, and add it to the `Symfony\Component\Console\Application` it creates so that the tool reports a version.

Fixes #29