### PR TITLE
Fix PHP 5.6 / 7.1 compatibility

### DIFF
--- a/bin/laminas-migration
+++ b/bin/laminas-migration
@@ -9,7 +9,6 @@
 
 namespace Laminas\Migration;
 
-use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
 
 if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
@@ -23,9 +22,7 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
     exit(1);
 }
 
-$version = strstr(Versions::getVersion('laminas/laminas-migration'), '@', true);
-
-$application = new Application('laminas-migration', $version);
+$application = new Application('laminas-migration', PackageVersions::getAppVersion());
 $application->addCommands([
     new Command\MigrateCommand(),
     new Command\NestedDepsCommand(),

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpunit/phpunit": "^9.0",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "phpcompatibility/php-compatibility": "^9.3",
+        "phpunit/phpunit": "^9.0",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "php": "^5.6 || ^7.0",
         "ext-json": "*",
         "laminas/laminas-zendframework-bridge": "^1.0",
-        "ocramius/package-versions": "^1.4",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {

--- a/src/PackageVersions.php
+++ b/src/PackageVersions.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Migration;
+
+use function array_filter;
+use function array_map;
+use function array_merge;
+use function array_reduce;
+use function assert;
+use function file_get_contents;
+use function is_array;
+use function is_object;
+use function is_string;
+use function json_decode;
+
+/**
+ * @internal
+ */
+final class PackageVersions
+{
+    const COMPOSER_INSTALLED = __DIR__ . '/../../../../composer/installed.json';
+    const COMPOSER_LOCK = __DIR__ . '/../../../../../composer.lock';
+    const APP_PACKAGE_NAME = 'laminas/laminas-migration';
+
+    /**
+     * @var array<string, string>
+     */
+    private $packages;
+
+    /**
+     * @param array<string, string> $packages
+     */
+    public function __construct(array $packages)
+    {
+        $this->packages = $packages;
+    }
+
+    /**
+     * Will build the version map from all given composer files
+     *
+     * @param string[] $composerFiles
+     * @return self
+     */
+    public static function fromComposerFiles(array $composerFiles)
+    {
+        return new self(
+            array_merge(
+                ...array_map(
+                    static function ($filename) {
+                        $data = json_decode(file_get_contents($filename), false);
+
+                        if (is_array($data)) {
+                            return self::buildMapFromPackageList($data);
+                        }
+
+                        assert(is_object($data) && isset($data->packages) && is_array($data->packages));
+                        assert(! isset($data->{'packages-dev'}) || is_array($data->{'packages-dev'}));
+
+                        return self::buildMapFromPackageList(
+                            $data->packages + (isset($data->{'packages-dev'}) ? $data->{'packages-dev'} : [])
+                        );
+                    },
+                    array_filter(
+                        $composerFiles,
+                        'is_readable'
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public static function getAppVersion()
+    {
+        return self::fromComposerFiles([self::COMPOSER_INSTALLED, self::COMPOSER_LOCK])
+            ->getPackageVersion(self::APP_PACKAGE_NAME);
+    }
+
+    /**
+     * @param string $packageName
+     * @return string
+     */
+    public function getPackageVersion($packageName)
+    {
+        return isset($this->packages[$packageName])
+            ? $this->packages[$packageName]
+            : 'UNKNOWN';
+    }
+
+    /**
+     * @param object[] $composerPackageList
+     * @return self
+     */
+    private static function buildMapFromPackageList(array $composerPackageList)
+    {
+        return array_reduce(
+            $composerPackageList,
+            static function (array $result, $package) {
+                assert(isset($package->name) && is_string($package->name));
+                assert(isset($package->version) && is_string($package->version));
+
+                $result[$package->name] = $package->version;
+
+                return $result;
+            },
+            []
+        );
+    }
+}

--- a/test/PackageVersionsTest.php
+++ b/test/PackageVersionsTest.php
@@ -64,7 +64,7 @@ class PackageVersionsTest extends TestCase
             ],
             'empty-list' => [
                 [],
-                '1.0.2'
+                'UNKNOWN'
             ],
         ];
     }

--- a/test/PackageVersionsTest.php
+++ b/test/PackageVersionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Migration;
+
+use Laminas\Migration\PackageVersions;
+use PHPUnit\Framework\TestCase;
+
+class PackageVersionsTest extends TestCase
+{
+    public function testShouldProvideVersionForKnownPackages(): void
+    {
+        self::assertSame(
+            '1.0.0',
+            (new PackageVersions(['foo/bar' => '1.0.0']))->getPackageVersion('foo/bar')
+        );
+    }
+
+    public function testShouldProvideUnknownForUnknownPackages(): void
+    {
+        self::assertSame(
+            'UNKNOWN',
+            (new PackageVersions([]))->getPackageVersion('foo/bar')
+        );
+    }
+
+    public function testShouldBuildFromComposerFiles(): void
+    {
+        $versions = PackageVersions::fromComposerFiles([
+            __DIR__ . '/composer-fixtures/installed.json',
+            __DIR__ . '/composer-fixtures/missing.json',
+            __DIR__ . '/composer-fixtures/composer.lock',
+        ]);
+
+        self::assertSame(
+            '1.0.2',
+            $versions->getPackageVersion(PackageVersions::APP_PACKAGE_NAME)
+        );
+    }
+}

--- a/test/PackageVersionsTest.php
+++ b/test/PackageVersionsTest.php
@@ -11,7 +11,7 @@ class PackageVersionsTest extends TestCase
 {
     public function testShouldProvideVersionForKnownPackages(): void
     {
-        self::assertSame(
+        $this->assertSame(
             '1.0.0',
             (new PackageVersions(['foo/bar' => '1.0.0']))->getPackageVersion('foo/bar')
         );
@@ -19,7 +19,7 @@ class PackageVersionsTest extends TestCase
 
     public function testShouldProvideUnknownForUnknownPackages(): void
     {
-        self::assertSame(
+        $this->assertSame(
             'UNKNOWN',
             (new PackageVersions([]))->getPackageVersion('foo/bar')
         );
@@ -77,7 +77,7 @@ class PackageVersionsTest extends TestCase
     {
         $versions = PackageVersions::fromComposerFiles($composerFiles);
 
-        self::assertSame(
+        $this->assertSame(
             $expectedVersion,
             $versions->getPackageVersion(PackageVersions::APP_PACKAGE_NAME)
         );
@@ -90,7 +90,7 @@ class PackageVersionsTest extends TestCase
 
         $version = PackageVersions::getAppVersion();
 
-        self::assertIsString($version); // Lack of proper return types due to php 5.6 compatibility
-        self::assertNotEmpty($version);
+        $this->assertIsString($version); // Lack of proper return types due to php 5.6 compatibility
+        $this->assertNotEmpty($version);
     }
 }

--- a/test/PackageVersionsTest.php
+++ b/test/PackageVersionsTest.php
@@ -25,17 +25,72 @@ class PackageVersionsTest extends TestCase
         );
     }
 
-    public function testShouldBuildFromComposerFiles(): void
+    public function provideComposerFilesTestData(): iterable
     {
-        $versions = PackageVersions::fromComposerFiles([
-            __DIR__ . '/composer-fixtures/installed.json',
-            __DIR__ . '/composer-fixtures/missing.json',
-            __DIR__ . '/composer-fixtures/composer.lock',
-        ]);
+        return [
+            'both-present' => [
+                [
+                    __DIR__ . '/composer-fixtures/installed.json',
+                    __DIR__ . '/composer-fixtures/composer.lock',
+                ],
+                '1.0.2'
+            ],
+            'lock-missing' => [
+                [
+                    __DIR__ . '/composer-fixtures/installed.json',
+                    __DIR__ . '/composer-fixtures/missing-composer.lock',
+                ],
+                '1.0.2'
+            ],
+            'installed-missing' => [
+                [
+                    __DIR__ . '/composer-fixtures/missing-installed.json',
+                    __DIR__ . '/composer-fixtures/composer.lock',
+                ],
+                '1.0.2'
+            ],
+            'both-missing' => [
+                [
+                    __DIR__ . '/composer-fixtures/missing-installed.json',
+                    __DIR__ . '/composer-fixtures/missing-composer.lock',
+                ],
+                'UNKNOWN'
+            ],
+            'only-one-provided' => [
+                [
+                    __DIR__ . '/composer-fixtures/installed.json',
+                ],
+                '1.0.2'
+            ],
+            'empty-list' => [
+                [],
+                '1.0.2'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideComposerFilesTestData
+     * @param string[] $composerFiles
+     */
+    public function testShouldBuildFromComposerFiles(array $composerFiles, string $expectedVersion): void
+    {
+        $versions = PackageVersions::fromComposerFiles($composerFiles);
 
         self::assertSame(
-            '1.0.2',
+            $expectedVersion,
             $versions->getPackageVersion(PackageVersions::APP_PACKAGE_NAME)
         );
+    }
+
+    public function testShouldAlwaysProvideAppVersion(): void
+    {
+        // Testing such a static, env-based method is not simple. We cannot ensure a specific environment
+        // so it can only check whether the method returns a non-empty string
+
+        $version = PackageVersions::getAppVersion();
+
+        self::assertIsString($version); // Lack of proper return types due to php 5.6 compatibility
+        self::assertNotEmpty($version);
     }
 }

--- a/test/composer-fixtures/composer.lock
+++ b/test/composer-fixtures/composer.lock
@@ -1,0 +1,469 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "32ecea089796c29b32e4698cab042942",
+    "packages": [
+        {
+            "name": "laminas/laminas-migration",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-migration.git",
+                "reference": "b4965062bd0f74bfb161742783627f6e99724e55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-migration/zipball/b4965062bd0f74bfb161742783627f6e99724e55",
+                "reference": "b4965062bd0f74bfb161742783627f6e99724e55",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "ocramius/package-versions": "^1.4",
+                "php": "^5.6 || ^7.0",
+                "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "roave/security-advisories": "dev-master"
+            },
+            "bin": [
+                "bin/laminas-migration"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Migration\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Migrate a Zend Framework project or third-party library to target Laminas/Expressive/Apigility",
+            "time": "2020-01-09T17:52:47+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev"
+                },
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "time": "2020-01-07T22:58:31+00:00"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/1d32342b8c1eb27353c8887c366147b4c2da673c",
+                "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": "^7.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8.6",
+                "doctrine/coding-standard": "^6.0.0",
+                "ext-zip": "*",
+                "infection/infection": "^0.13.4",
+                "phpunit/phpunit": "^8.2.5",
+                "vimeo/psalm": "^3.4.9"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2019-07-17T15:49:50+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/91c294166c38d8c0858a86fad76d8c14dc1144c8",
+                "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-01-25T15:56:29+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/34094cfa9abe1f0f14f48f490772db7a775559f2",
+                "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-01-13T11:15:53+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/5e66a0fa1070bf46bec4bea7962d285108edd675",
+                "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2020-01-13T11:15:53+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-11-18T17:27:11+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/test/composer-fixtures/installed.json
+++ b/test/composer-fixtures/installed.json
@@ -1,0 +1,469 @@
+[
+    {
+        "name": "laminas/laminas-migration",
+        "version": "1.0.2",
+        "version_normalized": "1.0.2.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/laminas/laminas-migration.git",
+            "reference": "b4965062bd0f74bfb161742783627f6e99724e55"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/laminas/laminas-migration/zipball/b4965062bd0f74bfb161742783627f6e99724e55",
+            "reference": "b4965062bd0f74bfb161742783627f6e99724e55",
+            "shasum": ""
+        },
+        "require": {
+            "ext-json": "*",
+            "laminas/laminas-zendframework-bridge": "^1.0",
+            "ocramius/package-versions": "^1.4",
+            "php": "^5.6 || ^7.0",
+            "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
+        },
+        "require-dev": {
+            "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+            "phpcompatibility/php-compatibility": "^9.3",
+            "roave/security-advisories": "dev-master"
+        },
+        "time": "2020-01-09T17:52:47+00:00",
+        "bin": [
+            "bin/laminas-migration"
+        ],
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev",
+                "dev-develop": "1.1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Laminas\\Migration\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "description": "Migrate a Zend Framework project or third-party library to target Laminas/Expressive/Apigility"
+    },
+    {
+        "name": "laminas/laminas-zendframework-bridge",
+        "version": "1.0.1",
+        "version_normalized": "1.0.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+            "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/0fb9675b84a1666ab45182b6c5b29956921e818d",
+            "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d",
+            "shasum": ""
+        },
+        "require": {
+            "php": "^5.6 || ^7.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1",
+            "squizlabs/php_codesniffer": "^3.5"
+        },
+        "time": "2020-01-07T22:58:31+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev",
+                "dev-develop": "1.1.x-dev"
+            },
+            "laminas": {
+                "module": "Laminas\\ZendFrameworkBridge"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "files": [
+                "src/autoload.php"
+            ],
+            "psr-4": {
+                "Laminas\\ZendFrameworkBridge\\": "src//"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "BSD-3-Clause"
+        ],
+        "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+        "keywords": [
+            "ZendFramework",
+            "autoloading",
+            "laminas",
+            "zf"
+        ]
+    },
+    {
+        "name": "ocramius/package-versions",
+        "version": "1.5.1",
+        "version_normalized": "1.5.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/Ocramius/PackageVersions.git",
+            "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/1d32342b8c1eb27353c8887c366147b4c2da673c",
+            "reference": "1d32342b8c1eb27353c8887c366147b4c2da673c",
+            "shasum": ""
+        },
+        "require": {
+            "composer-plugin-api": "^1.0.0",
+            "php": "^7.3.0"
+        },
+        "require-dev": {
+            "composer/composer": "^1.8.6",
+            "doctrine/coding-standard": "^6.0.0",
+            "ext-zip": "*",
+            "infection/infection": "^0.13.4",
+            "phpunit/phpunit": "^8.2.5",
+            "vimeo/psalm": "^3.4.9"
+        },
+        "time": "2019-07-17T15:49:50+00:00",
+        "type": "composer-plugin",
+        "extra": {
+            "class": "PackageVersions\\Installer",
+            "branch-alias": {
+                "dev-master": "1.6.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "PackageVersions\\": "src/PackageVersions"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Marco Pivetta",
+                "email": "ocramius@gmail.com"
+            }
+        ],
+        "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)"
+    },
+    {
+        "name": "psr/container",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/php-fig/container.git",
+            "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+            "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.0"
+        },
+        "time": "2017-02-14T16:28:37+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Psr\\Container\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "PHP-FIG",
+                "homepage": "http://www.php-fig.org/"
+            }
+        ],
+        "description": "Common Container Interface (PHP FIG PSR-11)",
+        "homepage": "https://github.com/php-fig/container",
+        "keywords": [
+            "PSR-11",
+            "container",
+            "container-interface",
+            "container-interop",
+            "psr"
+        ]
+    },
+    {
+        "name": "symfony/console",
+        "version": "v5.0.4",
+        "version_normalized": "5.0.4.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/console.git",
+            "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/console/zipball/91c294166c38d8c0858a86fad76d8c14dc1144c8",
+            "reference": "91c294166c38d8c0858a86fad76d8c14dc1144c8",
+            "shasum": ""
+        },
+        "require": {
+            "php": "^7.2.5",
+            "symfony/polyfill-mbstring": "~1.0",
+            "symfony/polyfill-php73": "^1.8",
+            "symfony/service-contracts": "^1.1|^2"
+        },
+        "conflict": {
+            "symfony/dependency-injection": "<4.4",
+            "symfony/event-dispatcher": "<4.4",
+            "symfony/lock": "<4.4",
+            "symfony/process": "<4.4"
+        },
+        "provide": {
+            "psr/log-implementation": "1.0"
+        },
+        "require-dev": {
+            "psr/log": "~1.0",
+            "symfony/config": "^4.4|^5.0",
+            "symfony/dependency-injection": "^4.4|^5.0",
+            "symfony/event-dispatcher": "^4.4|^5.0",
+            "symfony/lock": "^4.4|^5.0",
+            "symfony/process": "^4.4|^5.0",
+            "symfony/var-dumper": "^4.4|^5.0"
+        },
+        "suggest": {
+            "psr/log": "For using the console logger",
+            "symfony/event-dispatcher": "",
+            "symfony/lock": "",
+            "symfony/process": ""
+        },
+        "time": "2020-01-25T15:56:29+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "5.0-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Component\\Console\\": ""
+            },
+            "exclude-from-classmap": [
+                "/Tests/"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Fabien Potencier",
+                "email": "fabien@symfony.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony Console Component",
+        "homepage": "https://symfony.com"
+    },
+    {
+        "name": "symfony/polyfill-mbstring",
+        "version": "v1.14.0",
+        "version_normalized": "1.14.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/polyfill-mbstring.git",
+            "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/34094cfa9abe1f0f14f48f490772db7a775559f2",
+            "reference": "34094cfa9abe1f0f14f48f490772db7a775559f2",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.3"
+        },
+        "suggest": {
+            "ext-mbstring": "For best performance"
+        },
+        "time": "2020-01-13T11:15:53+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.14-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Polyfill\\Mbstring\\": ""
+            },
+            "files": [
+                "bootstrap.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony polyfill for the Mbstring extension",
+        "homepage": "https://symfony.com",
+        "keywords": [
+            "compatibility",
+            "mbstring",
+            "polyfill",
+            "portable",
+            "shim"
+        ]
+    },
+    {
+        "name": "symfony/polyfill-php73",
+        "version": "v1.14.0",
+        "version_normalized": "1.14.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/polyfill-php73.git",
+            "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/5e66a0fa1070bf46bec4bea7962d285108edd675",
+            "reference": "5e66a0fa1070bf46bec4bea7962d285108edd675",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.3"
+        },
+        "time": "2020-01-13T11:15:53+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.14-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Polyfill\\Php73\\": ""
+            },
+            "files": [
+                "bootstrap.php"
+            ],
+            "classmap": [
+                "Resources/stubs"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+        "homepage": "https://symfony.com",
+        "keywords": [
+            "compatibility",
+            "polyfill",
+            "portable",
+            "shim"
+        ]
+    },
+    {
+        "name": "symfony/service-contracts",
+        "version": "v2.0.1",
+        "version_normalized": "2.0.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/service-contracts.git",
+            "reference": "144c5e51266b281231e947b51223ba14acf1a749"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
+            "reference": "144c5e51266b281231e947b51223ba14acf1a749",
+            "shasum": ""
+        },
+        "require": {
+            "php": "^7.2.5",
+            "psr/container": "^1.0"
+        },
+        "suggest": {
+            "symfony/service-implementation": ""
+        },
+        "time": "2019-11-18T17:27:11+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "2.0-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Contracts\\Service\\": ""
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Generic abstractions related to writing services",
+        "homepage": "https://symfony.com",
+        "keywords": [
+            "abstractions",
+            "contracts",
+            "decoupling",
+            "interfaces",
+            "interoperability",
+            "standards"
+        ]
+    }
+]


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR aims to fix the Regression #31 (BC break).

It removes ocramius/package-versions and provides a local alternative that is compatible with php 5.6+ 