### PR TITLE
Expand versions of composer/semver we support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,26 @@ matrix:
     - php: 7.3
       env:
         - COMPAT_VERSION=7.3
-        - RUN_TESTS=1
+        - RUN_TESTS="phpunit/phpunit:^8.5 composer/semver:^1.0"
+    - php: 7.3
+      env:
+        - COMPAT_VERSION=7.3
+        - RUN_TESTS="phpunit/phpunit:^8.5 composer/semver:^2.0"
+    - php: 7.3
+      env:
+        - COMPAT_VERSION=7.3
+        - RUN_TESTS="phpunit/phpunit:^8.5 composer/semver:^3.0"
     - php: 7.4
       env:
         - COMPAT_VERSION=7.4
 
 install:
   - composer update $COMPOSER_ARGS
-  - if [[ $RUN_TESTS == '1' ]]; then composer require --dev "phpunit/phpunit:^8.5" ; fi
+  - if [[ $RUN_TESTS != '' ]]; then composer require $RUN_TESTS ; fi
   - stty cols 120 && composer show
 
 script:
-  - if [[ $RUN_TESTS == '1' ]]; then composer test ; fi
+  - if [[ $RUN_TESTS != '' ]]; then composer test ; fi
   - composer cs-check -- -p src --standard=PHPCompatibility --runtime-set testVersion $COMPAT_VERSION
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ext-json": "*",
-        "composer/semver": "^1.0 || ^2.0",
+        "composer/semver": "^1.0 || ^2.0 || ^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "ext-json": "*",
-        "composer/semver": "^2.0",
+        "composer/semver": "^1.0 || ^2.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },


### PR DESCRIPTION
As noted in #43, since the intention is to use this as a globally installed tool, we need to likely support v1 of composer/semver, as well as the more recent v3. This patch adds support for each, and tests against each major version via Travis.

Fixes #43