### PR TITLE
Warn users before removing composer.lock, vendor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpunit/phpunit": "^8.5",
         "roave/security-advisories": "dev-master"
     },
     "autoload": {

--- a/test/Command/MigrateCommandTest.php
+++ b/test/Command/MigrateCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-migration for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-migration/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-migration/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Migration\Command;
+
+use Laminas\Migration\Command\MigrateCommand;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StreamableInputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrateCommandTest extends TestCase
+{
+    public function testExecutionEndsInErrorWhenNonInteractiveAndUserOmitsFlagAcknowledgingDeletion(): void
+    {
+        /** @var InputInterface|MockObject $input */
+        $input = $this->createMock(InputInterface::class);
+        $input
+            ->expects($this->once())
+            ->method('getOption')
+            ->with($this->equalTo('yes'))
+            ->willReturn(null);
+        $input
+            ->expects($this->atLeastOnce())
+            ->method('isInteractive')
+            ->willReturn(false);
+
+        /** @var OutputInterface|MockObject $output */
+        $output = $this->createMock(OutputInterface::class);
+        $output
+            ->expects($this->once())
+            ->method('writeln')
+            ->with($this->stringContains('acknowledge this command will remove'));
+
+        $command = new MigrateCommand();
+
+        $this->assertSame(1, $command->run($input, $output));
+    }
+
+    public function testExecutionEndsInErrorWhenUserDoesNotConfirmDeletion(): void
+    {
+        $tempStream = fopen('php://temp', 'wb+');
+        fwrite($tempStream, 'no');
+        rewind($tempStream);
+
+        /** @var InputInterface|MockObject $input */
+        $input = $this->createMock(StreamableInputInterface::class);
+        $input
+            ->expects($this->once())
+            ->method('getOption')
+            ->with($this->equalTo('yes'))
+            ->willReturn(null);
+        $input
+            ->expects($this->atLeastOnce())
+            ->method('isInteractive')
+            ->willReturn(true);
+        $input
+            ->expects($this->atLeastOnce())
+            ->method('getStream')
+            ->willReturn($tempStream);
+
+        /** @var OutputInterface|MockObject $output */
+        $output = $this->createMock(OutputInterface::class);
+        $output
+            ->expects($this->once())
+            ->method('write')
+            ->with($this->stringContains('This command REMOVES your composer.lock'));
+
+        $command = new MigrateCommand();
+        $command->setHelperSet(new HelperSet([
+            new QuestionHelper(),
+        ]));
+
+        $this->assertSame(1, $command->run($input, $output));
+    }
+}


### PR DESCRIPTION
This patch adds two features:

- The option "--yes" or "-y", which is used to indicate that the user is aware that the composer.lock file and vendor directory get removed during migration.
- An interactive prompt that runs if the above option is not provided, and the console is interactive, asking the user to confirm that they are aware of the removals.

If the `--yes|-y` option is not provided, and the user does not confirm they are aware of the removals, the script aborts.

I'm considering this a _bugfix_, as it addresses a _problem_ users can run into during migration, which could lead to unwanted code removal.

Fixes #45