### PR TITLE
Php8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - php: 7.4
       env:
         - COMPAT_VERSION=7.4
-    - php: nightly
+    - php: 8.0
       env:
         - COMPAT_VERSION=8.0
         - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,33 +10,25 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env:
-        - COMPAT_VERSION=5.6
-    - php: 7.0
-      env:
-        - COMPAT_VERSION=7.0
-    - php: 7.1
-      env:
-        - COMPAT_VERSION=7.1
-    - php: 7.2
-      env:
-        - COMPAT_VERSION=7.2
     - php: 7.3
       env:
         - COMPAT_VERSION=7.3
-        - RUN_TESTS="phpunit/phpunit:^8.5 composer/semver:^1.0"
+        - RUN_TESTS="composer/semver:^1.0"
     - php: 7.3
       env:
         - COMPAT_VERSION=7.3
-        - RUN_TESTS="phpunit/phpunit:^8.5 composer/semver:^2.0"
+        - RUN_TESTS="composer/semver:^2.0"
     - php: 7.3
       env:
         - COMPAT_VERSION=7.3
-        - RUN_TESTS="phpunit/phpunit:^8.5 composer/semver:^3.0"
+        - RUN_TESTS="composer/semver:^3.0"
     - php: 7.4
       env:
         - COMPAT_VERSION=7.4
+    - php: nightly
+      env:
+        - COMPAT_VERSION=8.0
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 install:
   - composer update $COMPOSER_ARGS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#55](https://github.com/laminas/laminas-migration/pull/55) adds support for PHP 8.0.
 
 ### Changed
 
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- [#55](https://github.com/laminas/laminas-migration/pull/55) removes support for PHP versions prior to 7.3; if you need to use an older PHP version, use the 1.2.2 release instead.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "ext-json": "*",
         "composer/semver": "^1.0 || ^2.0 || ^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
@@ -15,7 +15,8 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-master",
+        "phpunit/phpunit": "9.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "roave/security-advisories": "dev-master",
-        "phpunit/phpunit": "9.3"
+        "phpunit/phpunit": "9.3",
+        "roave/security-advisories": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "bin/laminas-migration"
     ],
     "scripts": {
-        "check-compat": "for VERSION in 5.6 7.0 7.1 7.2 7.3 7.4;do ./vendor/bin/phpcs -- -p src --standard=PHPCompatibility --runtime-set testVersion $VERSION ; done",
+        "check-compat": "for VERSION in 7.3 7.4 8.0;do ./vendor/bin/phpcs -- -p src --standard=PHPCompatibility --runtime-set testVersion $VERSION ; done",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "phpcompatibility/php-compatibility": "^9.3",
         "roave/security-advisories": "dev-master",
         "phpunit/phpunit": "9.3"

--- a/test/FileFilterTest.php
+++ b/test/FileFilterTest.php
@@ -74,7 +74,7 @@ class FileFilterTest extends TestCase
         );
 
         foreach ($files as $file) {
-            $this->assertNotRegExp(
+            $this->assertDoesNotMatchRegularExpression(
                 '!/\.(git|hg|svn)(/|$)!',
                 $file->getRealPath(),
                 'One or more files matched a VCS directory'
@@ -94,7 +94,7 @@ class FileFilterTest extends TestCase
         );
 
         foreach ($files as $file) {
-            $this->assertNotRegExp(
+            $this->assertDoesNotMatchRegularExpression(
                 '!/vendor(/|$)!',
                 $file->getRealPath(),
                 'One or more files matched a VCS directory'
@@ -119,7 +119,7 @@ class FileFilterTest extends TestCase
         }, $exclusions));
 
         foreach ($files as $file) {
-            $this->assertNotRegExp(
+            $this->assertDoesNotMatchRegularExpression(
                 '!/(' . $pattern . ')$!',
                 $file->getRealPath(),
                 'One or more files matched a VCS directory'
@@ -187,7 +187,7 @@ class FileFilterTest extends TestCase
         }, $exclusions));
 
         foreach ($files as $file) {
-            $this->assertNotRegExp(
+            $this->assertDoesNotMatchRegularExpression(
                 '!/(' . $exclusionPattern . ')$!',
                 $file->getRealPath(),
                 sprintf('File %s matched a VCS directory', $file->getRealPath())


### PR DESCRIPTION
Updating to add PHP 8.0 support for #54 

In order to make this repository compatible, one has to follow these steps:
* [x]  Modify `composer.json` to provide support for PHP 8.0 by adding the constraint `~8.0.0`
* [x]  Modify `composer.json` to drop support for PHP less than 7.3
* [x]  Modify `composer.json` to implement phpunit 9.3 which supports PHP 7.3+
* [x]  Modify `.travis.yml` to ignore platform requirements when installing composer dependencies (simply add `--ignore-platform-reqs` to `COMPOSER_ARGS` env variable)
* [x]  Modify `.travis.yml` to add PHP 8.0 to the matrix (_NOTE_: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)
* [x]  Modify source code in case there are incompatibilities with PHP 8.0 - Only PHPUnit 9.3 deprecation changes done

Additional changes needed
* [x] Update of dev dependency "dealerdirect/phpcodesniffer-composer-installer" to v0.7.0 to be composer 2 compatible (used by PHP 8 travis image)
* [x] moved phpunit dependency from travis.yml to composer.json
* [x] updated PHP versions for check-compat script in composer.json