### PR TITLE
Update laminas-dependency-plugin constraint to 2.1

### DIFF
--- a/src/DependencyPlugin.php
+++ b/src/DependencyPlugin.php
@@ -28,7 +28,7 @@ class DependencyPlugin
 
         $io->writeln('<info>Injecting laminas-dependency-plugin into composer.json</info>');
         $json = json_decode(file_get_contents($path . '/composer.json'), true);
-        $json['require']['laminas/laminas-dependency-plugin'] = '^1.0';
+        $json['require']['laminas/laminas-dependency-plugin'] = '^2.1';
         Helper::writeJson($path . '/composer.json', $json);
     }
 }


### PR DESCRIPTION
This patch updates the constraint used when injecting the laminas-dependency-plugin to `^2.1` (current version), in order to allow usage with Composer v2 releases.

Fixes #57
