### PR TITLE
Psalm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
     - php: 7.4
       env:
         - COMPAT_VERSION=7.4
+        - STATIC_ANALYSIS=true
     - php: 8.0
       env:
         - COMPAT_VERSION=8.0
@@ -38,6 +39,7 @@ install:
 script:
   - if [[ $RUN_TESTS != '' ]]; then composer test ; fi
   - composer cs-check -- -p src --standard=PHPCompatibility --runtime-set testVersion $COMPAT_VERSION
+  - if [[ $STATIC_ANALYSIS != '' ]]; then composer static-analysis ; fi
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
+- [#61](https://github.com/laminas/laminas-migration/pull/61) changes the constructor of the `FileFilter` class to remove the initial `$path` argument, as well as to remove the `$path` property, as neither were used internally. This class is primarily an internal implementation detail; however, if you were using it in your own code, you may need to update how you create instances.
+
 - [#60](https://github.com/laminas/laminas-migration/pull/60) bumps the injected laminas/laminas-dependency-plugin constraint to `2.1` to allow usage with Composer v2 releases.
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpunit/phpunit": "9.3",
-        "roave/security-advisories": "dev-master"
+        "psalm/plugin-phpunit": "^0.15.0",
+        "roave/security-advisories": "dev-master",
+        "vimeo/psalm": "^4.3"
     },
     "autoload": {
         "psr-4": {
@@ -37,6 +39,7 @@
         "check-compat": "for VERSION in 7.3 7.4 8.0;do ./vendor/bin/phpcs -- -p src --standard=PHPCompatibility --runtime-set testVersion $VERSION ; done",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,16 +3,16 @@
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./vendor/autoload.php"
          colors="true">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="laminas-migration">
             <directory>./test/</directory>
             <exclude>./test/**/TestAsset/</exclude>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.3.2@57b53ff26237074fdf5cbcb034f7da5172be4524">
+  <file src="src/Command/MigrateCommand.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>bool</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$helper-&gt;ask($input, $output, $question)</code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument occurrences="6">
+      <code>$disableConfigProcessorInjection</code>
+      <code>$disableConfigProcessorInjection</code>
+      <code>$input-&gt;getOption('no-plugin')</code>
+      <code>$path</code>
+      <code>$path</code>
+      <code>$path</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/Command/NestedDepsCommand.php">
+    <MixedArgument occurrences="5">
+      <code>$package</code>
+      <code>$package-&gt;name</code>
+      <code>$package-&gt;name</code>
+      <code>$package['name']</code>
+      <code>$package['version']</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$data</code>
+      <code>$package</code>
+      <code>$root</code>
+    </MixedAssignment>
+    <MixedPropertyFetch occurrences="2">
+      <code>$data-&gt;installed</code>
+      <code>$package-&gt;name</code>
+    </MixedPropertyFetch>
+  </file>
+  <file src="src/ComposerLockFile.php">
+    <MixedArgument occurrences="5">
+      <code>$composerJsonData</code>
+      <code>$name</code>
+      <code>$package</code>
+      <code>$package</code>
+      <code>$version</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="4">
+      <code>$composerJsonData['require']</code>
+      <code>$composerJsonData['require-dev']</code>
+      <code>$composerLockData['packages']</code>
+      <code>$composerLockData['packages-dev']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="2">
+      <code>$composerJsonData['require']</code>
+      <code>$composerJsonData['require-dev']</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="2">
+      <code>$composerJsonData['require'][$packageName]</code>
+      <code>$composerJsonData['require-dev'][$packageName]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="12">
+      <code>$composerJsonData</code>
+      <code>$composerJsonData['require'][$packageName]</code>
+      <code>$composerJsonData['require-dev'][$packageName]</code>
+      <code>$composerLockData</code>
+      <code>$name</code>
+      <code>$package</code>
+      <code>$package</code>
+      <code>$packageName</code>
+      <code>$packageName</code>
+      <code>$version</code>
+      <code>$version</code>
+      <code>$version</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/DependencyPlugin.php">
+    <MixedArgument occurrences="1">
+      <code>$json</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$json['require']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$json['require']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="1">
+      <code>$json</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/PackageVersions.php">
+    <MixedArgumentTypeCoercion occurrences="4">
+      <code>$allPackageLists ? array_shift($allPackageLists) : []</code>
+      <code>$data</code>
+      <code>$data-&gt;packages + (isset($data-&gt;{'packages-dev'}) ? $data-&gt;{'packages-dev'} : [])</code>
+      <code>array_merge(...$allPackageLists)</code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/SpecialCase/ComposerJsonExtraZFSpecialCase.php">
+    <MixedArgument occurrences="3">
+      <code>$composer</code>
+      <code>$extraLaminas</code>
+      <code>$extraZf</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="3">
+      <code>$composer['extra']['laminas']</code>
+      <code>$composer['extra']['zf']</code>
+      <code>$composer['extra']['zf']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$composer['extra']['laminas']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="4">
+      <code>$composer</code>
+      <code>$composer</code>
+      <code>$extraLaminas</code>
+      <code>$extraZf</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/SpecialCase/ComposerJsonZendFrameworkPackageSpecialCase.php">
+    <MissingClosureParamType occurrences="4">
+      <code>$a</code>
+      <code>$a</code>
+      <code>$b</code>
+      <code>$b</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="4">
+      <code>$composer[$section]</code>
+      <code>$composer[$section]['zendframework/zendframework']</code>
+      <code>json_decode($content, true)</code>
+      <code>json_decode($content, true)</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="3">
+      <code>$composer[$section][$package]</code>
+      <code>$composer[$section]['zendframework/zendframework']</code>
+      <code>$composer[$section]['zendframework/zendframework']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$composer[$section][$normalized]</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="3">
+      <code>$composer[$section][$normalized]</code>
+      <code>$constraint</code>
+      <code>$version</code>
+    </MixedAssignment>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>strtolower</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="src/VendorDirectory.php">
+    <MixedArrayAccess occurrences="1">
+      <code>$composer['config']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$composer</code>
+    </MixedAssignment>
+  </file>
+  <file src="test/FileFilterTest.php">
+    <MixedAssignment occurrences="5">
+      <code>$file</code>
+      <code>$file</code>
+      <code>$file</code>
+      <code>$file</code>
+      <code>$file</code>
+    </MixedAssignment>
+  </file>
+  <file src="test/PackageVersionsTest.php">
+    <InternalClass occurrences="5">
+      <code>PackageVersions::APP_PACKAGE_NAME</code>
+      <code>PackageVersions::fromComposerFiles($composerFiles)</code>
+      <code>PackageVersions::getAppVersion()</code>
+      <code>new PackageVersions(['foo/bar' =&gt; '1.0.0'])</code>
+      <code>new PackageVersions([])</code>
+    </InternalClass>
+    <InternalMethod occurrences="5">
+      <code>PackageVersions::fromComposerFiles($composerFiles)</code>
+      <code>PackageVersions::getAppVersion()</code>
+      <code>getPackageVersion</code>
+      <code>getPackageVersion</code>
+      <code>getPackageVersion</code>
+    </InternalMethod>
+  </file>
+  <file src="test/SpecialCase/ComposerJsonExtraZFSpecialCaseTest.php">
+    <MixedAssignment occurrences="2">
+      <code>$expected</code>
+      <code>$replacements</code>
+    </MixedAssignment>
+  </file>
+  <file src="test/SpecialCase/ComposerJsonZendFrameworkPackageSpecialCaseTest.php">
+    <MixedAssignment occurrences="2">
+      <code>$expected</code>
+      <code>$replacements</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>iterable</code>
+    </MixedInferredReturnType>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="bin"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="bin"/>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -101,6 +101,9 @@ To update your lockfile, you can just use `composer update --lock`
 
 EOH;
 
+    /**
+     * @return void
+     */
     protected function configure()
     {
         $this->setName('migrate')
@@ -216,8 +219,10 @@ EOH;
 
     /**
      * @param string $path
+     *
+     * @return void
      */
-    private function removeComposerLock($path, SymfonyStyle $io)
+    private function removeComposerLock($path, SymfonyStyle $io): void
     {
         $composerLockFile = new ComposerLockFile();
         $composerLockFile->remove($path, $io);
@@ -225,8 +230,10 @@ EOH;
 
     /**
      * @param string $path
+     *
+     * @return void
      */
-    private function removeVendorDirectory($path, SymfonyStyle $io)
+    private function removeVendorDirectory($path, SymfonyStyle $io): void
     {
         $vendorDirectory = new VendorDirectory();
         $vendorDirectory->remove($path, $io);
@@ -235,8 +242,10 @@ EOH;
     /**
      * @param string $path
      * @param null|bool $noPluginOption
+     *
+     * @return void
      */
-    private function injectDependencyPlugin($path, $noPluginOption, SymfonyStyle $io)
+    private function injectDependencyPlugin($path, $noPluginOption, SymfonyStyle $io): void
     {
         $dependencyPlugin = new DependencyPlugin();
         $dependencyPlugin->inject($path, $noPluginOption, $io);
@@ -244,8 +253,10 @@ EOH;
 
     /**
      * @param string $path
+     *
+     * @return void
      */
-    private function migrateProjectFiles($path, callable $filter, SymfonyStyle $io)
+    private function migrateProjectFiles($path, callable $filter, SymfonyStyle $io): void
     {
         $migration = new MigrateProject([
             new ComposerJsonExtraZFSpecialCase(),
@@ -270,8 +281,10 @@ EOH;
     /**
      * @param string $path
      * @param bool $disableConfigProcessorInjection
+     *
+     * @return void
      */
-    private function injectBridgeModule($path, $disableConfigProcessorInjection, SymfonyStyle $io)
+    private function injectBridgeModule($path, $disableConfigProcessorInjection, SymfonyStyle $io): void
     {
         $bridgeModule = new BridgeModule();
         $bridgeModule->inject($path, $disableConfigProcessorInjection, $io);
@@ -280,8 +293,10 @@ EOH;
     /**
      * @param string $path
      * @param bool $disableConfigProcessorInjection
+     *
+     * @return void
      */
-    private function injectBridgeConfigPostProcessor($path, $disableConfigProcessorInjection, SymfonyStyle $io)
+    private function injectBridgeConfigPostProcessor($path, $disableConfigProcessorInjection, SymfonyStyle $io): void
     {
         $bridgeConfigPostProcessor = new BridgeConfigPostProcessor();
         $bridgeConfigPostProcessor->inject($path, $disableConfigProcessorInjection, $io);
@@ -289,8 +304,10 @@ EOH;
 
     /**
      * @param string $path
+     *
+     * @return void
      */
-    private function synchronizeComposerJsonWithComposerLock($path, SymfonyStyle $io)
+    private function synchronizeComposerJsonWithComposerLock($path, SymfonyStyle $io): void
     {
         $lockFile = new ComposerLockFile();
         $lockFile->moveLockedVersionsToComposerJson($path, $io);

--- a/src/Command/NestedDepsCommand.php
+++ b/src/Command/NestedDepsCommand.php
@@ -34,6 +34,9 @@ replacements of their ZF equivalents, this will remove the ZF packages
 as well.
 EOH;
 
+    /**
+     * @return void
+     */
     public function configure()
     {
         $this->setName('nested-deps')
@@ -100,7 +103,7 @@ EOH;
             return 0;
         }
 
-        $createPackageSpec = static function (array $package) {
+        $createPackageSpec = static function (array $package): string {
             return sprintf('"%s:~%s"', Helper::replace($package['name']), ltrim($package['version'], 'v'));
         };
 

--- a/src/ComposerLockFile.php
+++ b/src/ComposerLockFile.php
@@ -21,6 +21,8 @@ class ComposerLockFile
 {
     /**
      * @param string $path
+     *
+     * @return void
      */
     public function remove($path, SymfonyStyle $io)
     {
@@ -34,6 +36,8 @@ class ComposerLockFile
 
     /**
      * @param string $path
+     *
+     * @return void
      */
     public function moveLockedVersionsToComposerJson($path, SymfonyStyle $io)
     {
@@ -52,7 +56,12 @@ class ComposerLockFile
         $composerLockData = json_decode(file_get_contents($composerLock), true);
         $composerJsonData = json_decode(file_get_contents($composerJson), true);
 
-        $mapper = static function (array $package) {
+        $mapper = /**
+         * @return (mixed|string)[]
+         *
+         * @psalm-return array{0: mixed, 1: mixed|string}
+         */
+        static function (array $package): array {
             $name = $package['name'];
             $version = $package['version'];
             $vendor = explode('/', $name, 2)[0];
@@ -82,7 +91,7 @@ class ComposerLockFile
         Helper::writeJson($composerJson, $composerJsonData);
     }
 
-    private function lockfile($path)
+    private function lockfile(string $path): string
     {
         return $path . '/composer.lock';
     }

--- a/src/FileFilter.php
+++ b/src/FileFilter.php
@@ -8,9 +8,7 @@
 
 namespace Laminas\Migration;
 
-use RecursiveIterator;
 use SplFileInfo;
-use SplTempFileObject;
 
 use function array_map;
 use function array_unshift;
@@ -35,21 +33,16 @@ class FileFilter
      */
     private $fileExclusions = [];
 
-    /** @var string */
-    private $path = [];
-
     /** @var string[] */
     private $regexes = [];
 
     /**
-     * @param string $path
      * @param string[] $regexes
      * @param string[] $exclusions
      * @return self
      */
-    public function __construct($path, array $regexes, array $exclusions)
+    public function __construct(array $regexes, array $exclusions)
     {
-        $this->path       = $path;
         $this->regexes    = $regexes;
         $this->exclusions = $exclusions;
 

--- a/src/FileFilter.php
+++ b/src/FileFilter.php
@@ -135,14 +135,14 @@ class FileFilter
         return true;
     }
 
-    private function prependCommonExclusions()
+    private function prependCommonExclusions(): void
     {
         array_unshift($this->exclusions, '/.hg');
         array_unshift($this->exclusions, '/.svn');
         array_unshift($this->exclusions, '/.git');
     }
 
-    private function prepareExclusionPatterns()
+    private function prepareExclusionPatterns(): void
     {
         // Create list of directory patterns to check against
         $directory = new Directory();

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -20,6 +20,7 @@ class Helper
     {
         static $replacements;
 
+        /** @var Replacements $replacements */
         $replacements = $replacements ?: new Replacements([
             'Expressive\\' => 'Mezzio\\',
         ]);

--- a/src/MigrateProject.php
+++ b/src/MigrateProject.php
@@ -38,6 +38,9 @@ class MigrateProject
         $this->specialCases = $specialCases;
     }
 
+    /**
+     * @param string $path
+     */
     public function __invoke($path, callable $filter, SymfonyStyle $io)
     {
         $io->writeln('<info>Performing migration replacements</info>');

--- a/src/PackageVersions.php
+++ b/src/PackageVersions.php
@@ -25,9 +25,9 @@ use function json_decode;
  */
 final class PackageVersions
 {
-    const COMPOSER_INSTALLED = __DIR__ . '/../../../../composer/installed.json';
-    const COMPOSER_LOCK = __DIR__ . '/../../../../../composer.lock';
-    const APP_PACKAGE_NAME = 'laminas/laminas-migration';
+    public const COMPOSER_INSTALLED = __DIR__ . '/../../../../composer/installed.json';
+    public const COMPOSER_LOCK = __DIR__ . '/../../../../../composer.lock';
+    public const APP_PACKAGE_NAME = 'laminas/laminas-migration';
 
     /**
      * @var array<string, string>
@@ -51,7 +51,7 @@ final class PackageVersions
     public static function fromComposerFiles(array $composerFiles)
     {
         $allPackageLists = array_map(
-            static function ($filename) {
+            static function ($filename): array {
                 $data = json_decode(file_get_contents($filename), false);
 
                 if (is_array($data)) {
@@ -109,7 +109,7 @@ final class PackageVersions
     {
         return array_reduce(
             $composerPackageList,
-            static function (array $result, $package) {
+            static function (array $result, object $package) {
                 assert(isset($package->name) && is_string($package->name));
                 assert(isset($package->version) && is_string($package->version));
 

--- a/src/PackageVersions.php
+++ b/src/PackageVersions.php
@@ -100,9 +100,12 @@ final class PackageVersions
 
     /**
      * @param object[] $composerPackageList
-     * @return self
+     *
+     * @return (mixed|string)[]
+     *
+     * @psalm-return array<array-key, mixed|string>
      */
-    private static function buildMapFromPackageList(array $composerPackageList)
+    private static function buildMapFromPackageList(array $composerPackageList): array
     {
         return array_reduce(
             $composerPackageList,

--- a/src/SpecialCase/ComposerJsonZendFrameworkPackageSpecialCase.php
+++ b/src/SpecialCase/ComposerJsonZendFrameworkPackageSpecialCase.php
@@ -73,6 +73,10 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         $semver   = new Semver();
         $versions = array_keys(self::ZF_VERSIONS);
         usort($versions, static function ($a, $b) {
+            if (! is_string($a) || ! is_string($b)) {
+                return $b <=> $a;
+            }
+
             // Reverse sort by version
             $result = version_compare($a, $b);
             if ($result === 0) {
@@ -124,6 +128,10 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         // Sort the section.
         // Items not in vendor/package format bubble up.
         uksort($composer[$section], static function ($a, $b) {
+            if (! is_string($a) || ! is_string($b)) {
+                return $a <=> $b;
+            }
+
             if (strpos($a, '/') === false && strpos($b, '/') === false) {
                 return strcasecmp($a, $b);
             }
@@ -142,7 +150,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         return $composer;
     }
 
-    const ZF_VERSIONS = [
+    public const ZF_VERSIONS = [
         '2.0.0'  => self::ZF_2_0_0__2_0_6,
         '2.0.1'  => self::ZF_2_0_0__2_0_6,
         '2.0.2'  => self::ZF_2_0_0__2_0_6,
@@ -201,7 +209,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         '3.0.0'  => self::ZF_3_0_0,
     ];
 
-    const ZF_2_0_0__2_0_6 = [
+    public const ZF_2_0_0__2_0_6 = [
         'zendframework/zend-acl'            => 'self.version',
         'zendframework/zend-authentication' => 'self.version',
         'zendframework/zend-barcode'        => 'self.version',
@@ -251,7 +259,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         'zendframework/zend-xmlrpc'         => 'self.version',
     ];
 
-    const ZF_2_0_7__2_0_8 = [
+    public const ZF_2_0_7__2_0_8 = [
         'zendframework/zend-authentication'  => 'self.version',
         'zendframework/zend-barcode'         => 'self.version',
         'zendframework/zend-cache'           => 'self.version',
@@ -302,7 +310,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         'zendframework/zend-xmlrpc'          => 'self.version',
     ];
 
-    const ZF_2_1_0__2_2_1 = [
+    public const ZF_2_1_0__2_2_1 = [
         'zendframework/zend-authentication'   => 'self.version',
         'zendframework/zend-barcode'          => 'self.version',
         'zendframework/zend-cache'            => 'self.version',
@@ -355,7 +363,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         'zendframework/zend-xmlrpc'           => 'self.version',
     ];
 
-    const ZF_2_2_2__2_4_13 = [
+    public const ZF_2_2_2__2_4_13 = [
         'zendframework/zend-authentication'   => 'self.version',
         'zendframework/zend-barcode'          => 'self.version',
         'zendframework/zend-cache'            => 'self.version',
@@ -409,7 +417,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         'zendframework/zend-xmlrpc'           => 'self.version',
     ];
 
-    const ZF_2_5_0 = [
+    public const ZF_2_5_0 = [
         'zendframework/zend-authentication'   => '~2.5.0',
         'zendframework/zend-barcode'          => '~2.5.0',
         'zendframework/zend-cache'            => '~2.5.0',
@@ -464,7 +472,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         'zendframework/zendxml'               => '~1.0',
     ];
 
-    const ZF_2_5_1 = [
+    public const ZF_2_5_1 = [
         'zendframework/zend-authentication'   => '~2.5.0',
         'zendframework/zend-barcode'          => '~2.5.0',
         'zendframework/zend-cache'            => '~2.5.0',
@@ -518,7 +526,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         'zendframework/zendxml'               => '~1.0',
     ];
 
-    const ZF_2_5_2 = [
+    public const ZF_2_5_2 = [
         'zendframework/zend-authentication'   => '~2.5.0',
         'zendframework/zend-barcode'          => '~2.5.0',
         'zendframework/zend-cache'            => '~2.5.0',
@@ -572,7 +580,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         'zendframework/zendxml'               => '^1.0.1',
     ];
 
-    const ZF_2_5_3 = [
+    public const ZF_2_5_3 = [
         'zendframework/zend-authentication'   => '^2.5',
         'zendframework/zend-barcode'          => '^2.5',
         'zendframework/zend-cache'            => '^2.5',
@@ -626,7 +634,7 @@ class ComposerJsonZendFrameworkPackageSpecialCase implements SpecialCaseInterfac
         'zendframework/zendxml'               => '^1.0.1',
     ];
 
-    const ZF_3_0_0 = [
+    public const ZF_3_0_0 = [
         'zendframework/zend-authentication'    => '^2.5.3',
         'zendframework/zend-barcode'           => '^2.6',
         'zendframework/zend-cache'             => '^2.7.1',

--- a/src/VendorDirectory.php
+++ b/src/VendorDirectory.php
@@ -14,8 +14,6 @@ use function file_get_contents;
 use function json_decode;
 use function sprintf;
 
-use const DIRECTORY_SEPARATOR;
-
 class VendorDirectory extends Directory
 {
     /**
@@ -27,7 +25,7 @@ class VendorDirectory extends Directory
         $path      = $this->normalizePath($path);
         $composer  = json_decode(file_get_contents($path . '/composer.json'), true);
         return isset($composer['config']['vendor-dir'])
-            ? sprintf('%s/%s', $path, $composer['config']['vendor-dir'])
+            ? sprintf('%s/%s', $path, (string) $composer['config']['vendor-dir'])
             : sprintf('%s/vendor', $path);
     }
 

--- a/src/VendorDirectory.php
+++ b/src/VendorDirectory.php
@@ -33,6 +33,8 @@ class VendorDirectory extends Directory
 
     /**
      * @param string $path
+     *
+     * @return void
      */
     public function remove($path, SymfonyStyle $io)
     {

--- a/test/Command/MigrateCommandTest.php
+++ b/test/Command/MigrateCommandTest.php
@@ -21,7 +21,10 @@ class MigrateCommandTest extends TestCase
 {
     public function testExecutionEndsInErrorWhenNonInteractiveAndUserOmitsFlagAcknowledgingDeletion(): void
     {
-        /** @var InputInterface|MockObject $input */
+        /**
+         * @var InputInterface|MockObject $input
+         * @psalm-var InputInterface&MockObject $input
+         */
         $input = $this->createMock(InputInterface::class);
         $input
             ->expects($this->once())
@@ -33,7 +36,10 @@ class MigrateCommandTest extends TestCase
             ->method('isInteractive')
             ->willReturn(false);
 
-        /** @var OutputInterface|MockObject $output */
+        /**
+         * @var OutputInterface|MockObject $output
+         * @psalm-var OutputInterface&MockObject $output
+         */
         $output = $this->createMock(OutputInterface::class);
         $output
             ->expects($this->once())
@@ -51,7 +57,10 @@ class MigrateCommandTest extends TestCase
         fwrite($tempStream, 'no');
         rewind($tempStream);
 
-        /** @var InputInterface|MockObject $input */
+        /**
+         * @var InputInterface|MockObject $input
+         * @psalm-var InputInterface&MockObject $input
+         */
         $input = $this->createMock(StreamableInputInterface::class);
         $input
             ->expects($this->once())
@@ -67,7 +76,10 @@ class MigrateCommandTest extends TestCase
             ->method('getStream')
             ->willReturn($tempStream);
 
-        /** @var OutputInterface|MockObject $output */
+        /**
+         * @var OutputInterface|MockObject $output
+         * @psalm-var OutputInterface&MockObject $output
+         */
         $output = $this->createMock(OutputInterface::class);
         $output
             ->expects($this->once())

--- a/test/DirectoryTest.php
+++ b/test/DirectoryTest.php
@@ -13,6 +13,12 @@ use PHPUnit\Framework\TestCase;
 
 class DirectoryTest extends TestCase
 {
+    /**
+     * @psalm-return iterable<string, array{
+     *     0: string,
+     *     1: string
+     * }>
+     */
     public function pathsToNormalize(): iterable
     {
         yield 'unix'    => ['/home/user/project', '/home/user/project'];

--- a/test/FileFilterTest.php
+++ b/test/FileFilterTest.php
@@ -54,6 +54,9 @@ class FileFilterTest extends TestCase
         }
     }
 
+    /**
+     * @param false|string $path
+     */
     public function getDirectoryIterator($path): RecursiveDirectoryIterator
     {
         return new RecursiveDirectoryIterator(
@@ -62,7 +65,7 @@ class FileFilterTest extends TestCase
         );
     }
 
-    public function testOmitsVcsDirectoriesByDefault()
+    public function testOmitsVcsDirectoriesByDefault(): void
     {
         $path   = realpath(dirname(__DIR__));
         $filter = new FileFilter($path, [], []);
@@ -82,7 +85,7 @@ class FileFilterTest extends TestCase
         }
     }
 
-    public function testDoesNotReturnFilesInExcludedDirectories()
+    public function testDoesNotReturnFilesInExcludedDirectories(): void
     {
         $path   = realpath(dirname(__DIR__));
         $filter = new FileFilter($path, [], ['/vendor']);
@@ -102,7 +105,7 @@ class FileFilterTest extends TestCase
         }
     }
 
-    public function testDoesNotReturnExcludedFiles()
+    public function testDoesNotReturnExcludedFiles(): void
     {
         $exclusions = ['CHANGELOG.md', 'COPYRIGHT.md', 'LICENSE.md'];
         $path       = realpath(dirname(__DIR__));
@@ -127,7 +130,7 @@ class FileFilterTest extends TestCase
         }
     }
 
-    public function testOnlyReturnsFilesMatchingOneOrMoreRegexes()
+    public function testOnlyReturnsFilesMatchingOneOrMoreRegexes(): void
     {
         $regexes = [
             'src/.*?',
@@ -160,7 +163,7 @@ class FileFilterTest extends TestCase
         }
     }
 
-    public function testOnlyReturnsFilesMatchingARegexThatAreNotAlsoExcluded()
+    public function testOnlyReturnsFilesMatchingARegexThatAreNotAlsoExcluded(): void
     {
         $regexes = [
             'src/.*?',

--- a/test/FileFilterTest.php
+++ b/test/FileFilterTest.php
@@ -15,6 +15,7 @@ use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
+use SplFileInfo;
 
 class FileFilterTest extends TestCase
 {
@@ -55,7 +56,7 @@ class FileFilterTest extends TestCase
     }
 
     /**
-     * @param false|string $path
+     * @param string $path
      */
     public function getDirectoryIterator($path): RecursiveDirectoryIterator
     {
@@ -68,7 +69,7 @@ class FileFilterTest extends TestCase
     public function testOmitsVcsDirectoriesByDefault(): void
     {
         $path   = realpath(dirname(__DIR__));
-        $filter = new FileFilter($path, [], []);
+        $filter = new FileFilter([], []);
         $files  = new RecursiveIteratorIterator(
             new RecursiveCallbackFilterIterator(
                 $this->getDirectoryIterator($path),
@@ -77,6 +78,7 @@ class FileFilterTest extends TestCase
         );
 
         foreach ($files as $file) {
+            /** @var SplFileInfo $file */
             $this->assertDoesNotMatchRegularExpression(
                 '!/\.(git|hg|svn)(/|$)!',
                 $file->getRealPath(),
@@ -88,7 +90,7 @@ class FileFilterTest extends TestCase
     public function testDoesNotReturnFilesInExcludedDirectories(): void
     {
         $path   = realpath(dirname(__DIR__));
-        $filter = new FileFilter($path, [], ['/vendor']);
+        $filter = new FileFilter([], ['/vendor']);
         $files  = new RecursiveIteratorIterator(
             new RecursiveCallbackFilterIterator(
                 $this->getDirectoryIterator($path),
@@ -97,6 +99,7 @@ class FileFilterTest extends TestCase
         );
 
         foreach ($files as $file) {
+            /** @var SplFileInfo $file */
             $this->assertDoesNotMatchRegularExpression(
                 '!/vendor(/|$)!',
                 $file->getRealPath(),
@@ -109,7 +112,7 @@ class FileFilterTest extends TestCase
     {
         $exclusions = ['CHANGELOG.md', 'COPYRIGHT.md', 'LICENSE.md'];
         $path       = realpath(dirname(__DIR__));
-        $filter     = new FileFilter($path, [], $exclusions);
+        $filter     = new FileFilter([], $exclusions);
         $files      = new RecursiveIteratorIterator(
             new RecursiveCallbackFilterIterator(
                 $this->getDirectoryIterator($path),
@@ -122,6 +125,7 @@ class FileFilterTest extends TestCase
         }, $exclusions));
 
         foreach ($files as $file) {
+            /** @var SplFileInfo $file */
             $this->assertDoesNotMatchRegularExpression(
                 '!/(' . $pattern . ')$!',
                 $file->getRealPath(),
@@ -139,7 +143,7 @@ class FileFilterTest extends TestCase
         ];
 
         $path   = realpath(dirname(__DIR__));
-        $filter = new FileFilter($path, $regexes, []);
+        $filter = new FileFilter($regexes, []);
         $files  = new RecursiveIteratorIterator(
             new RecursiveCallbackFilterIterator(
                 $this->getDirectoryIterator($path),
@@ -148,6 +152,7 @@ class FileFilterTest extends TestCase
         );
 
         foreach ($files as $file) {
+            /** @var SplFileInfo $file */
             $matches = false;
             foreach ($regexes as $regex) {
                 $pattern = sprintf('#%s#', $regex);
@@ -177,7 +182,7 @@ class FileFilterTest extends TestCase
         ];
 
         $path   = realpath(dirname(__DIR__));
-        $filter = new FileFilter($path, $regexes, $exclusions);
+        $filter = new FileFilter($regexes, $exclusions);
         $files  = new RecursiveIteratorIterator(
             new RecursiveCallbackFilterIterator(
                 $this->getDirectoryIterator($path),
@@ -190,6 +195,7 @@ class FileFilterTest extends TestCase
         }, $exclusions));
 
         foreach ($files as $file) {
+            /** @var SplFileInfo $file */
             $this->assertDoesNotMatchRegularExpression(
                 '!/(' . $exclusionPattern . ')$!',
                 $file->getRealPath(),

--- a/test/PackageVersionsTest.php
+++ b/test/PackageVersionsTest.php
@@ -25,6 +25,12 @@ class PackageVersionsTest extends TestCase
         );
     }
 
+    /**
+     * @psalm-return iterable<string, array{
+     *     0: array<array-key, string>,
+     *     1: string
+     * }>
+     */
     public function provideComposerFilesTestData(): iterable
     {
         return [
@@ -90,7 +96,6 @@ class PackageVersionsTest extends TestCase
 
         $version = PackageVersions::getAppVersion();
 
-        $this->assertIsString($version); // Lack of proper return types due to php 5.6 compatibility
         $this->assertNotEmpty($version);
     }
 }

--- a/test/SpecialCase/ComposerJsonExtraZFSpecialCaseTest.php
+++ b/test/SpecialCase/ComposerJsonExtraZFSpecialCaseTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class ComposerJsonExtraZFSpecialCaseTest extends TestCase
 {
-    public function testReplacesZendFrameworkPackageWithAppropriatePackagesAtAppropriateConstraint()
+    public function testReplacesZendFrameworkPackageWithAppropriatePackagesAtAppropriateConstraint(): void
     {
         $specialCase      = new ComposerJsonExtraZFSpecialCase();
         $file             = sprintf('%s/fixtures/extra/composer.json', __DIR__);

--- a/test/SpecialCase/ComposerJsonZendFrameworkPackageSpecialCaseTest.php
+++ b/test/SpecialCase/ComposerJsonZendFrameworkPackageSpecialCaseTest.php
@@ -38,9 +38,12 @@ class ComposerJsonZendFrameworkPackageSpecialCaseTest extends TestCase
 
     /**
      * @dataProvider expectedReplacements
+     *
      * @param string $directory
+     *
+     * @return void
      */
-    public function testReplacesZendFrameworkPackageWithAppropriatePackagesAtAppropriateConstraint($directory)
+    public function testReplacesZendFrameworkPackageWithAppropriatePackagesAtAppropriateConstraint($directory): void
     {
         $specialCase      = new ComposerJsonZendFrameworkPackageSpecialCase();
         $file             = sprintf('%s/fixtures/%s/composer.json', __DIR__, $directory);


### PR DESCRIPTION
- incorporate psalm into QA toolchain
- autofixes as performed by psalm
- update phpunit configuration
- apply psalm and create baseline
- fix low-hanging fruit:
  - Previously defined constants are given explicit "public" visibility (to keep BC)
  - `FileFilter` removes unused `$path` property and constructor argument.
    Since the class is internal, this is an acceptable change.
  - Assertions are added where they resolve typing issues.
  - Argument and return type hints are added to closures to resolve type issues.
  - Explicit type checking is added to sorting closures to resolve type issues while retaining sorting expectations.

Fixes #53
